### PR TITLE
Use a likelier chrome executable on Linux

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -56,7 +56,7 @@ find_chrome <- function() {
     path
 
   } else if (is_linux()) {
-    Sys.which("chrome")
+    Sys.which("google-chrome")
 
   } else {
     stop("Platform currently not supported")


### PR DESCRIPTION
I believe Chrome is typically installed as a symlink named `google-chrome` on Debian and RedHat-derived distributions.