### PR TITLE
add a check for chromium-browser

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -34,8 +34,11 @@ find_chrome <- function() {
     path
 
   } else if (is_linux()) {
-    Sys.which("google-chrome")
-
+    path <- Sys.which("google-chrome")
+    if (nchar(path) == 0) {
+      path <- Sys.which("chromium-browser")
+    }
+    path
   } else {
     stop("Platform currently not supported")
   }

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -38,6 +38,9 @@ find_chrome <- function() {
     if (nchar(path) == 0) {
       path <- Sys.which("chromium-browser")
     }
+    if (nchar(path) == 0) {
+      stop("`google-chrome` and `chromium-browser` were not found. Try setting the CHROMOTE_CHROME environment variable or adding one of these executables to your PATH.")
+    }
     path
   } else {
     stop("Platform currently not supported")


### PR DESCRIPTION
if `google-chrome` is not found on linux, try `chromium-browser`, which is the apt-available alternative (on Ubuntu 18.04), and is the binary installed by `yum install chromium` on Centos7 as well. This is helpful for e.g. RStudio Server Pro

Ultimately, the error message here was not helpful: 
```
ChromoteSession$new()
#> Error: <c_error in rethrow_call(c_processx_exec, command, c(command, args), stdin,  ...:
 cannot start processx process '' (system error 2, No such file or directory) @unix/processx.c:584 (processx_exec)>
```

A pointer to the `CHROMOTE_CHROME` environment variable (and perhaps a clear error) would be desirable here. This approach is pretty naive, so definitely no hard feelings if you want to implement differently!