### PR TITLE
Add system requirements for chromium

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Description: An implementation of the Chrome Devtools Protocol, for controlling 
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
+SystemRequirements: chromium: chromium (rpm) or chromium-browser (deb)
 Imports:
     jsonlite,
     websocket,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Description: An implementation of the Chrome Devtools Protocol, for controlling 
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
-SystemRequirements: chromium: chromium (rpm) or chromium-browser (deb)
+SystemRequirements: Chrome or other Chromium-based browser. chromium: chromium (rpm) or chromium-browser (deb)
+
 Imports:
     jsonlite,
     websocket,


### PR DESCRIPTION
Especially given the pattern used by https://github.com/rstudio/r-system-requirements , I thought it would be good to highlight the `SystemRequirements` here.