### PR TITLE
Use threaded version of websocket

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,10 +11,10 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     jsonlite,
-    websocket,
+    websocket (>= 1.1.0.9001),
     processx,
     R6,
-    later (>= 0.8.0.9003),
+    later (>= 1.0.0.9002),
     promises (>= 1.0.1.9002),
     magrittr,
     rlang,
@@ -23,5 +23,6 @@ Suggests:
     showimage
 Remotes:
     r-lib/later,
-    rstudio/promises
+    rstudio/promises,
+    rstudio/websocket
 RoxygenNote: 6.1.1

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -76,7 +76,6 @@ Chromote <- R6Class(
         private$event_manager <- EventManager$new(self)
         private$is_active_ <- TRUE
 
-        private$schedule_child_loop()
         self$wait_for(p)
 
         private$register_default_event_listeners()
@@ -352,40 +351,7 @@ Chromote <- R6Class(
     # Event loop for the websocket and the parent event loop
     # =========================================================================
     child_loop = NULL,
-    parent_loop = NULL,
-    child_loop_is_scheduled = FALSE,
-
-    schedule_child_loop = function() {
-      # Make sure that if this function is called multiple times, there aren't
-      # multiple streams of overlapping callbacks.
-      if (private$child_loop_is_scheduled)
-        return()
-
-      # If the websocket has closed, there's no reason to run the child loop
-      # anymore.
-      if (private$ws$readyState() == 3) {
-        self$debug_log("Websocket state is closed.")
-        private$is_active_ <- FALSE
-        return()
-      }
-
-      # This tells the parent loop to schedule one run of the child
-      # (private) loop.
-      later(private$run_child_loop, 0.01, loop = private$parent_loop)
-
-      private$child_loop_is_scheduled <- TRUE
-    },
-
-    run_child_loop = function() {
-      private$child_loop_is_scheduled <- FALSE
-
-      tryCatch(
-        run_now(loop = private$child_loop),
-        finally = {
-          private$schedule_child_loop()
-        }
-      )
-    }
+    parent_loop = NULL
   )
 )
 


### PR DESCRIPTION
This should be merged after https://github.com/rstudio/websocket/pull/62.

Before this change and the corresponding one in websocket, Chromote idles at ~6.5% CPU usage. After these changes, it idles at 0%.

Can be tested with:

```R
remotes::install_github('rstudio/websocket@wch-threads')
remotes::install_github('rstudio/chromote@threaded-websocket', dependencies = FALSE)
```
