### PR TITLE
Use updated version of later and websocket with auto-running child event loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chromote
 Title: Headless Chrome Web Browser Interface
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: c(
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),
     person(given = "RStudio", role = c("cph", "fnd"))
@@ -11,10 +11,10 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     jsonlite,
-    websocket,
+    websocket (>= 1.1.0.9002),
     processx,
     R6,
-    later (>= 0.8.0.9003),
+    later (>= 0.8.0.9004),
     promises (>= 1.0.1.9002),
     magrittr,
     rlang,
@@ -23,6 +23,7 @@ Suggests:
     showimage
 Remotes:
     r-lib/later,
+    rstudio/websocket,
     rstudio/promises
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -32,10 +32,8 @@ Chromote <- R6Class(
 
       private$command_callbacks <- fastmap()
 
-      private$parent_loop <- current_loop()
-
       # Use a private event loop to drive the websocket
-      private$child_loop <- create_loop(autorun = FALSE)
+      private$child_loop <- create_loop(parent = current_loop())
 
       with_loop(private$child_loop, {
         private$ws <- WebSocket$new(
@@ -76,7 +74,6 @@ Chromote <- R6Class(
         private$event_manager <- EventManager$new(self)
         private$is_active_ <- TRUE
 
-        private$schedule_child_loop()
         self$wait_for(p)
 
         private$register_default_event_listeners()
@@ -349,43 +346,9 @@ Chromote <- R6Class(
     sessions = list(),
 
     # =========================================================================
-    # Event loop for the websocket and the parent event loop
+    # Private event loop for the websocket
     # =========================================================================
-    child_loop = NULL,
-    parent_loop = NULL,
-    child_loop_is_scheduled = FALSE,
-
-    schedule_child_loop = function() {
-      # Make sure that if this function is called multiple times, there aren't
-      # multiple streams of overlapping callbacks.
-      if (private$child_loop_is_scheduled)
-        return()
-
-      # If the websocket has closed, there's no reason to run the child loop
-      # anymore.
-      if (private$ws$readyState() == 3) {
-        self$debug_log("Websocket state is closed.")
-        private$is_active_ <- FALSE
-        return()
-      }
-
-      # This tells the parent loop to schedule one run of the child
-      # (private) loop.
-      later(private$run_child_loop, 0.01, loop = private$parent_loop)
-
-      private$child_loop_is_scheduled <- TRUE
-    },
-
-    run_child_loop = function() {
-      private$child_loop_is_scheduled <- FALSE
-
-      tryCatch(
-        run_now(loop = private$child_loop),
-        finally = {
-          private$schedule_child_loop()
-        }
-      )
-    }
+    child_loop = NULL
   )
 )
 


### PR DESCRIPTION
This uses the threaded version of websocket and the version of later which auto-runs child event loops. This reduces the idle CPU usage of Chromote from 6% to 0% on my computer.

This should be merged after https://github.com/r-lib/later/pull/119.