### PR TITLE
Search for "chromium" path on Linux

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -46,6 +46,9 @@ find_chrome <- function() {
       path <- Sys.which("chromium-browser")
     }
     if (nchar(path) == 0) {
+      path <- Sys.which("chromium")
+    }
+    if (nchar(path) == 0) {
       message("`google-chrome` and `chromium-browser` were not found. Try setting the CHROMOTE_CHROME environment variable or adding one of these executables to your PATH.")
       path <- NULL
     }


### PR DESCRIPTION
On Ubuntu 20.04, `chromium` is installed in `/snap/bin/chromium`.  
`find_chrome()` does not find it unless it also looks up `"chromium"`.