### PR TITLE
Add auto_events to ChromoteSession

### DIFF
--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -26,13 +26,18 @@ ChromoteSession <- R6Class(
     #' @param wait_ If `FALSE`, return a [promises::promise()] of a new
     #'   `ChromoteSession` object. Otherwise, block during initialization, and
     #'   return a `ChromoteSession` object directly.
+    #' @param auto_events If `NULL` (the default), use the `auto_events` setting
+    #'   from the parent `Chromote` object. If `TRUE`, enable automatic
+    #'   event enabling/disabling; if `FALSE`, disable automatic event
+    #'   enabling/disabling.
     #' @return A new `ChromoteSession` object.
     initialize = function(
       parent = default_chromote_object(),
       width = 992,
       height = 744,
       targetId = NULL,
-      wait_ = TRUE
+      wait_ = TRUE,
+      auto_events = NULL
     ) {
       self$parent <- parent
 
@@ -67,6 +72,7 @@ ChromoteSession <- R6Class(
       # Graft the entries from self$protocol onto self
       list2env(self$protocol, self)
 
+      private$auto_events <- auto_events
       private$event_manager <- EventManager$new(self)
       private$is_active_ <- TRUE
 
@@ -165,7 +171,11 @@ ChromoteSession <- R6Class(
     },
 
     get_auto_events = function() {
-      self$parent$get_auto_events()
+      if (!is.null(private$auto_events)) {
+        private$auto_events
+      } else {
+        self$parent$get_auto_events()
+      }
     },
 
     debug_log = function(...) {
@@ -189,6 +199,7 @@ ChromoteSession <- R6Class(
     is_active_ = NULL,
     event_manager = NULL,
     pixel_ratio = NULL,
+    auto_events = NULL,
     init_promise_ = NULL,
 
     register_event_listener = function(event, callback = NULL, timeout = NULL) {

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -41,7 +41,8 @@ Create a new \code{ChromoteSession} object.
   width = 992,
   height = 744,
   targetId = NULL,
-  wait_ = TRUE
+  wait_ = TRUE,
+  auto_events = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -66,6 +67,11 @@ arguments determine its viewport size.}
 \item{\code{wait_}}{If \code{FALSE}, return a \code{\link[promises:promise]{promises::promise()}} of a new
 \code{ChromoteSession} object. Otherwise, block during initialization, and
 return a \code{ChromoteSession} object directly.}
+
+\item{\code{auto_events}}{If \code{NULL} (the default), use the \code{auto_events} setting
+from the parent \code{Chromote} object. If \code{TRUE}, enable automatic
+event enabling/disabling; if \code{FALSE}, disable automatic event
+enabling/disabling.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Closes #40.

Please note that I haven't really tested this. I am not 100% sure that this will work correctly, if, for example, a ChromoteSession has `auto_events=FALSE` while the parent Chromote has `auto_events=TRUE` (or vice versa). Similarly, I'm not 100% it will work correctly if two ChromoteSessions have different `auto_events` settings.

@RLesur if you could test this out, I would appreciate it.