### PR TITLE
Inspector is not exposed by Chromote

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -302,13 +302,6 @@ Chromote <- R6Class(
         private$sessions[[sid]] <- NULL
         session$mark_closed()
       })
-
-      # When a target crashes, raise a warning.
-      # The session cannot be closed because no session id is returned by the
-      # Inspector.targetCrashed event
-      self$protocol$Inspector$targetCrashed(function(msg) {
-        warning("Chromote has received a Inspector.targetCrashed event. This means that the ChromoteSession has probably crashed.")
-      })
     },
 
     # =========================================================================

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -86,13 +86,14 @@ ChromoteSession <- R6Class(
         })
 
       # When a target crashes, raise a warning.
-      # The session cannot be closed because no session id is returned by the
-      # Inspector.targetCrashed event
       if (!is.null(self$Inspector$targetCrashed)) {
         p <- p$
           then(function(value) {
             self$Inspector$targetCrashed(timeout_ = NULL, wait_ = FALSE, function(value) {
               warning("Chromote has received a Inspector.targetCrashed event. This means that the ChromoteSession has probably crashed.")
+              # Even if no targetId nor sessionId is returned by Inspector.targetCashed
+              # mark the session as closed. This will close all sessions..
+              self$mark_closed()
             })
           })
       }

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -88,12 +88,14 @@ ChromoteSession <- R6Class(
       # When a target crashes, raise a warning.
       # The session cannot be closed because no session id is returned by the
       # Inspector.targetCrashed event
-      p <- p$
-        then(function(value) {
-          self$Inspector$targetCrashed(timeout_ = NULL, wait_ = FALSE, function(value) {
-            warning("Chromote has received a Inspector.targetCrashed event. This means that the ChromoteSession has probably crashed.")
+      if (!is.null(self$Inspector$targetCrashed)) {
+        p <- p$
+          then(function(value) {
+            self$Inspector$targetCrashed(timeout_ = NULL, wait_ = FALSE, function(value) {
+              warning("Chromote has received a Inspector.targetCrashed event. This means that the ChromoteSession has probably crashed.")
+            })
           })
-        })
+      }
 
       if (wait_) {
         self$wait_for(p)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -85,6 +85,16 @@ ChromoteSession <- R6Class(
           private$pixel_ratio <- value$result$value
         })
 
+      # When a target crashes, raise a warning.
+      # The session cannot be closed because no session id is returned by the
+      # Inspector.targetCrashed event
+      p <- p$
+        then(function(value) {
+          self$Inspector$targetCrashed(timeout_ = NULL, wait_ = FALSE, function(value) {
+            warning("Chromote has received a Inspector.targetCrashed event. This means that the ChromoteSession has probably crashed.")
+          })
+        })
+
       if (wait_) {
         self$wait_for(p)
       } else {


### PR DESCRIPTION
The aim of this PR is to fix #44 (regression introduced by #42).
The `Inspector` domain is only available to the ChromoteSession and not Chromote. So, this PR moves the code introduced by #42 in the ChromoteSession.