### PR TITLE
Add custom delay before taking screenshot

### DIFF
--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -7,6 +7,7 @@ ChromoteSession$set("public", "screenshot",
     expand = NULL,
     scale = 1,
     show = FALSE,
+    delay = 0.5,
     wait_ = TRUE
   ) {
     force(filename)
@@ -79,9 +80,9 @@ ChromoteSession$set("public", "screenshot",
         )
 
         promise(function(resolve, reject) {
-          # TODO: Wait 0.5 second for resize to complete. Can we wait for an
-          # event instead?
-          later(function() resolve(TRUE), 0.5)
+          # Wait `delay` seconds for resize to complete. For complicated apps this may need to be longer.
+          ## TODO: Can we wait for an event instead?
+          later(function() resolve(TRUE), delay)
         })
       })
 


### PR DESCRIPTION
Sometimes half a second is not enough of a delay for an app to equilibrate after a resize event. By adding a `delay` parameter the user can now make it longer if necessary.