### PR TITLE
Startup args documentation

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -4,6 +4,16 @@
 Chrome <- R6Class("Chrome",
   inherit = Browser,
   public = list(
+    #' @description Create a new Chrome object.
+    #' @param path Location of chrome installation
+    #' @param args A character vector of command-line arguments passed when
+    #'   initializing Chromium. Single on-off arguments are passed as single
+    #'   values (e.g.`"--disable-gpu"`), arguments with a value are given with a
+    #'   nested character vector (e.g. `c("--force-color-profile", "srgb")`).
+    #'   See
+    #'   [here](https://peter.sh/experiments/chromium-command-line-switches/)
+    #'   for a list of possible arguments.
+    #' @return A new `Chrome` object.
     initialize = function(path = find_chrome(), args = character(0)) {
       if (is.null(path)) {
         stop("Invalid path to Chrome")

--- a/man/Chrome.Rd
+++ b/man/Chrome.Rd
@@ -33,10 +33,29 @@ Class representing a local Chrome process
 \if{html}{\out{<a id="method-new"></a>}}
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
+Create a new Chrome object.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chrome$new(path = find_chrome(), args = character(0))}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{path}}{Location of chrome installation}
+
+\item{\code{args}}{A character vector of command-line arguments passed when
+initializing Chromium. Single on-off arguments are passed as single
+values (e.g.\code{"--disable-gpu"}), arguments with a value are given with a
+nested character vector (e.g. \code{c("--force-color-profile", "srgb")}).
+See
+\href{https://peter.sh/experiments/chromium-command-line-switches/}{here}
+for a list of possible arguments.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A new \code{Chrome} object.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -228,6 +228,7 @@ A new \code{ChromoteSession} object.
   expand = NULL,
   scale = 1,
   show = FALSE,
+  delay = 0.5,
   wait_ = TRUE
 )}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Adds a short bit of documentation about how to pass command-line arguments for Chromium startup. Without docs, it was a bit confusing to figure out the format for both binary on/off arguments and key-value arguments. 

Also in building the docs, the .rd for the screenshot function from #50 with its new delay argument was rebuilt.