### PR TITLE
Add `use_srgb_color_profile` argument to increase portability of screenshots

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -6,6 +6,15 @@ Chrome <- R6Class("Chrome",
   public = list(
     #' @description Create a new Chrome object.
     #' @param path Location of chrome installation
+    #' @param use_srgb_color_profile Should a standard color profile (srgb) be
+    #'   used when taking screenshots? Forcing a standard profile increases
+    #'   portability of screenshots as colors will differ when the monitor of
+    #'   screenshotting machines have different color profiles. The downside is
+    #'   that colors of output may be slightly different than what you see in
+    #'   your browser.
+    #'   Equivalent to settings `args = '--force-color-profile="srgb"'`.
+    #'   If you want to use another option you can set it using the `args`
+    #'   parameter.
     #' @param args A character vector of command-line arguments passed when
     #'   initializing Chromium. Single on-off arguments are passed as single
     #'   values (e.g.`"--disable-gpu"`), arguments with a value are given with a
@@ -14,11 +23,11 @@ Chrome <- R6Class("Chrome",
     #'   [here](https://peter.sh/experiments/chromium-command-line-switches/)
     #'   for a list of possible arguments.
     #' @return A new `Chrome` object.
-    initialize = function(path = find_chrome(), args = character(0)) {
+    initialize = function(path = find_chrome(), use_srgb_color_profile = TRUE, args = character(0)) {
       if (is.null(path)) {
         stop("Invalid path to Chrome")
       }
-      res <- launch_chrome(path, args)
+      res <- launch_chrome(path, use_srgb_color_profile, args)
       private$host <- "127.0.0.1"
       private$process <- res$process
       private$port <- res$port
@@ -71,14 +80,20 @@ find_chrome <- function() {
 }
 
 
-launch_chrome <- function(path = find_chrome(), args = character(0)) {
+launch_chrome <- function(path = find_chrome(), use_srgb_color_profile = TRUE, args = character(0)) {
   if (is.null(path)) {
     stop("Invalid path to Chrome")
   }
 
+
   p <- process$new(
     command = path,
-    args = c("--headless", "--remote-debugging-port=0", args),
+    args = c(
+      "--headless",
+      "--remote-debugging-port=0",
+      if (use_srgb_color_profile) '--force-color-profile="srgb"',
+      args
+    ),
     supervise = TRUE,
     stdout = tempfile("chrome-stdout-", fileext = ".log"),
     stderr = tempfile("chrome-stderr-", fileext = ".log")

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -16,10 +16,8 @@ Chrome <- R6Class("Chrome",
     #'   If you want to use another option you can set it using the `args`
     #'   parameter.
     #' @param args A character vector of command-line arguments passed when
-    #'   initializing Chromium. Single on-off arguments are passed as single
-    #'   values (e.g.`"--disable-gpu"`), arguments with a value are given with a
-    #'   nested character vector (e.g. `c("--force-color-profile", "srgb")`).
-    #'   See
+    #'   initializing Chromium. E.g. `c("--disable-gpu",
+    #'   '--force-color-profile="srgb"')`. See
     #'   [here](https://peter.sh/experiments/chromium-command-line-switches/)
     #'   for a list of possible arguments.
     #' @return A new `Chrome` object.

--- a/man/Chrome.Rd
+++ b/man/Chrome.Rd
@@ -35,7 +35,11 @@ Class representing a local Chrome process
 \subsection{Method \code{new()}}{
 Create a new Chrome object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chrome$new(path = find_chrome(), args = character(0))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chrome$new(
+  path = find_chrome(),
+  use_srgb_color_profile = TRUE,
+  args = character(0)
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -43,11 +47,18 @@ Create a new Chrome object.
 \describe{
 \item{\code{path}}{Location of chrome installation}
 
+\item{\code{use_srgb_color_profile}}{Should a standard color profile (srgb) be
+used when taking screenshots? Forcing a standard profile increases
+portability of screenshots as colors will differ when the monitor of
+screenshotting machines have different color profiles. The downside is
+that colors of output may be slightly different than what you see in
+your browser.
+Equivalent to settings \code{args = '--force-color-profile="srgb"'}.
+If you want to use another option you can set it using the \code{args}
+parameter.}
+
 \item{\code{args}}{A character vector of command-line arguments passed when
-initializing Chromium. Single on-off arguments are passed as single
-values (e.g.\code{"--disable-gpu"}), arguments with a value are given with a
-nested character vector (e.g. \code{c("--force-color-profile", "srgb")}).
-See
+initializing Chromium. E.g. \code{c("--disable-gpu", '--force-color-profile="srgb"')}. See
 \href{https://peter.sh/experiments/chromium-command-line-switches/}{here}
 for a list of possible arguments.}
 }


### PR DESCRIPTION
_This is the same PR as https://github.com/rstudio/webshot2/pull/23  just now applied at the chromote level so it doesn't have to be reimplemented by every wrapping package that will probably want the functionality._

By default, chromote will mirror the color profile of the main monitor of the machine used to take the screenshot. This means that screenshots taken on a laptop plugged into an external monitor will often have subtly different colors than one taken when the laptop is using its built-in monitor. This problem will be even more likely across machines.

To remedy this we set the [Chrome headless argument `force-color-profile`](https://peter.sh/experiments/chromium-command-line-switches/#force-color-profile) to `"srgb"` so the color profile used is always the same across machines/monitors. 

The `use_srgb_color_profile` argument defaults to `TRUE`. This may break visual tests that use screenshots generated by chromote but I think it's ultimately a better default than the non-portable mirroring of the current monitor's profile. 