### PR TITLE
Bump browser size to 1200 x 1600 (3:4 ratio)

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -109,7 +109,7 @@ Chromote <- R6Class(
     # Session management
     # =========================================================================
 
-    new_session = function(width = 992, height = 774, targetId = NULL, wait_ = TRUE) {
+    new_session = function(width = 1200, height = 1600, targetId = NULL, wait_ = TRUE) {
       session <- ChromoteSession$new(self, width, height, targetId, wait_ = FALSE)
 
       # ChromoteSession$new() always returns the object, but the

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -33,8 +33,8 @@ ChromoteSession <- R6Class(
     #' @return A new `ChromoteSession` object.
     initialize = function(
       parent = default_chromote_object(),
-      width = 1920,
-      height = 1200,
+      width = 1200,
+      height = 1600,
       targetId = NULL,
       wait_ = TRUE,
       auto_events = NULL
@@ -157,7 +157,7 @@ ChromoteSession <- R6Class(
       private$is_active_
     },
 
-    new_session = function(width = 992, height = 774, targetId = NULL, wait_ = TRUE) {
+    new_session = function(width = 1200, height = 1600, targetId = NULL, wait_ = TRUE) {
       self$parent$new_session(width = width, height = height, targetId = targetId, wait_ = wait_)
     },
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -33,8 +33,8 @@ ChromoteSession <- R6Class(
     #' @return A new `ChromoteSession` object.
     initialize = function(
       parent = default_chromote_object(),
-      width = 992,
-      height = 744,
+      width = 1920,
+      height = 1200,
       targetId = NULL,
       wait_ = TRUE,
       auto_events = NULL


### PR DESCRIPTION
Related: https://en.wikipedia.org/wiki/Graphics_display_resolution#WUXGA_(1920%C3%971200)

IDK why the screen is so small to begin with.  

## Questions
- [ ] Should we default it to `letter` size so that the screen does not move when users take a screenshot?