### PR TITLE
Use BootStrap responsive breakpoint of Large devices

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -109,7 +109,7 @@ Chromote <- R6Class(
     # Session management
     # =========================================================================
 
-    new_session = function(width = 1200, height = 1600, targetId = NULL, wait_ = TRUE) {
+    new_session = function(width = 992, height = 1323, targetId = NULL, wait_ = TRUE) {
       session <- ChromoteSession$new(self, width, height, targetId, wait_ = FALSE)
 
       # ChromoteSession$new() always returns the object, but the

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -157,7 +157,7 @@ ChromoteSession <- R6Class(
       private$is_active_
     },
 
-    new_session = function(width = 1200, height = 1600, targetId = NULL, wait_ = TRUE) {
+    new_session = function(width = 992, height = 1323, targetId = NULL, wait_ = TRUE) {
       self$parent$new_session(width = width, height = height, targetId = targetId, wait_ = wait_)
     },
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -33,8 +33,8 @@ ChromoteSession <- R6Class(
     #' @return A new `ChromoteSession` object.
     initialize = function(
       parent = default_chromote_object(),
-      width = 1200,
-      height = 1600,
+      width = 992,
+      height = 1323,
       targetId = NULL,
       wait_ = TRUE,
       auto_events = NULL

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -79,12 +79,7 @@ Chromote class
 \if{latex}{\out{\hypertarget{method-new_session}{}}}
 \subsection{Method \code{new_session()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$new_session(
-  width = 1200,
-  height = 1600,
-  targetId = NULL,
-  wait_ = TRUE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$new_session(width = 992, height = 1323, targetId = NULL, wait_ = TRUE)}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -38,8 +38,8 @@ Create a new \code{ChromoteSession} object.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$new(
   parent = default_chromote_object(),
-  width = 1200,
-  height = 1600,
+  width = 992,
+  height = 1323,
   targetId = NULL,
   wait_ = TRUE,
   auto_events = NULL
@@ -121,8 +121,8 @@ A new \code{ChromoteSession} object.
 \subsection{Method \code{new_session()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$new_session(
-  width = 1200,
-  height = 1600,
+  width = 992,
+  height = 1323,
   targetId = NULL,
   wait_ = TRUE
 )}\if{html}{\out{</div>}}


### PR DESCRIPTION
Keep 4:3 ratio.

Bootstrap uses a breakpoint of 992px for desktops: https://getbootstrap.com/docs/4.0/layout/overview/