### PR TITLE
Remove `ChromoteSession$get_parent()` and lock `$protocol`

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -90,6 +90,8 @@ Chromote <- R6Class(
         # Populate methods while the connection is being established.
         protocol_spec <- jsonlite::fromJSON(self$url("/json/protocol"), simplifyVector = FALSE)
         self$protocol <- process_protocol(protocol_spec, self$.__enclos_env__)
+        lockBinding("protocol", self)
+
         # self$protocol is a list of domains, each of which is a list of
         # methods. Graft the entries from self$protocol onto self
         list2env(self$protocol, self)

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -310,7 +310,7 @@ Chromote <- R6Class(
     },
 
     #' @description Retrieve active status
-    #' Once initialized, the value returned is `TRUE`. If `$stop()` has been
+    #' Once initialized, the value returned is `TRUE`. If `$close()` has been
     #' called, this value will be `FALSE`.
     is_active = function() {
       private$is_active_
@@ -323,7 +323,7 @@ Chromote <- R6Class(
     },
 
     #' @description Close the [`Browser`] object
-    stop = function() {
+    close = function() {
       private$is_active_ <- FALSE
       self$Browser$close()
     },

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -85,6 +85,7 @@ ChromoteSession <- R6Class(
       # send_command() method with a sessionId -- that is how the command is
       # scoped to this session.
       self$protocol <- protocol_reassign_envs(parent$protocol, env = self$.__enclos_env__)
+      lockBinding("protocol", self)
 
       # Graft the entries from self$protocol onto self
       list2env(self$protocol, self)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -54,6 +54,8 @@ ChromoteSession <- R6Class(
       auto_events = NULL
     ) {
       self$parent <- parent
+      lockBinding("parent", self) # do not allow `$parent` to be set!
+
       self$default_timeout <- parent$default_timeout
 
       # Create a session from the Chromote. Basically the same code as
@@ -372,12 +374,6 @@ ChromoteSession <- R6Class(
     #' #> [1] "https://www.r-project.org/"}
     new_session = function(width = 992, height = 1323, targetId = NULL, wait_ = TRUE) {
       self$parent$new_session(width = width, height = height, targetId = targetId, wait_ = wait_)
-    },
-
-    #' @description
-    #' Retrieve the [`Chromote`] object associated with this session.
-    get_parent = function() {
-      self$parent
     },
 
     #' @description

--- a/README.Rmd
+++ b/README.Rmd
@@ -316,7 +316,7 @@ cm <- Chromote$new()
 b1 <- cm$new_session()
 
 # Or:
-b <- ChromoteSession$new(parent = Chromote$new())
+b1 <- ChromoteSession$new(parent = cm)
 ```
 
 Note that if you use either of these methods, the new `Chromote` object will _not_ be set as the default that is used by future calls to `ChromoteSesssion$new()`. See [Specifying which browser to use](#specifying-which-browser-to-use) for information on setting the default `Chromote` object.

--- a/README.Rmd
+++ b/README.Rmd
@@ -230,7 +230,7 @@ This is different from shutting down the browser process. If you call `b$close()
 To shut down the process, call:
 
 ```R
-b1$parent$stop()
+b1$parent$close()
 ```
 
 `b1$parent` is a `Chromote` object (as opposed to `ChromoteSession`), which represents the browser as a whole. This is explained in [The Chromote object model](#the-chromote-object-model).

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ new tab by calling `b1$new_session()`.
 To shut down the process, call:
 
 ``` r
-b1$parent$stop()
+b1$parent$close()
 ```
 
 `b1$parent` is a `Chromote` object (as opposed to `ChromoteSession`),

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ cm <- Chromote$new()
 b1 <- cm$new_session()
 
 # Or:
-b <- ChromoteSession$new(parent = Chromote$new())
+b <- ChromoteSession$new(parent = cm)
 ```
 
 Note that if you use either of these methods, the new `Chromote` object

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ cm <- Chromote$new()
 b1 <- cm$new_session()
 
 # Or:
-b <- ChromoteSession$new(parent = cm)
+b1 <- ChromoteSession$new(parent = cm)
 ```
 
 Note that if you use either of these methods, the new `Chromote` object

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -69,7 +69,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-url}{\code{Chromote$url()}}
 \item \href{#method-is_active}{\code{Chromote$is_active()}}
 \item \href{#method-get_browser}{\code{Chromote$get_browser()}}
-\item \href{#method-stop}{\code{Chromote$stop()}}
+\item \href{#method-close}{\code{Chromote$close()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -334,7 +334,7 @@ Create url for a given path
 \if{latex}{\out{\hypertarget{method-is_active}{}}}
 \subsection{Method \code{is_active()}}{
 Retrieve active status
-Once initialized, the value returned is \code{TRUE}. If \verb{$stop()} has been
+Once initialized, the value returned is \code{TRUE}. If \verb{$close()} has been
 called, this value will be \code{FALSE}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_active()}\if{html}{\out{</div>}}
@@ -352,12 +352,12 @@ Retrieve \code{\link{Browser}}` object
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-stop"></a>}}
-\if{latex}{\out{\hypertarget{method-stop}{}}}
-\subsection{Method \code{stop()}}{
+\if{html}{\out{<a id="method-close"></a>}}
+\if{latex}{\out{\hypertarget{method-close}{}}}
+\subsection{Method \code{close()}}{
 Close the \code{\link{Browser}} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$stop()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$close()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -208,7 +208,6 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-screenshot}{\code{ChromoteSession$screenshot()}}
 \item \href{#method-screenshot_pdf}{\code{ChromoteSession$screenshot_pdf()}}
 \item \href{#method-new_session}{\code{ChromoteSession$new_session()}}
-\item \href{#method-get_parent}{\code{ChromoteSession$get_parent()}}
 \item \href{#method-get_session_id}{\code{ChromoteSession$get_session_id()}}
 \item \href{#method-wait_for}{\code{ChromoteSession$wait_for()}}
 \item \href{#method-debug_log}{\code{ChromoteSession$debug_log()}}
@@ -585,16 +584,6 @@ b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
 }
 \if{html}{\out{</div>}}
 
-}
-
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_parent"></a>}}
-\if{latex}{\out{\hypertarget{method-get_parent}{}}}
-\subsection{Method \code{get_parent()}}{
-Retrieve the \code{\link{Chromote}} object associated with this session.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_parent()}\if{html}{\out{</div>}}
 }
 
 }


### PR DESCRIPTION
Fixes #75

Changes
- [x] Remove `ChromoteSession$get_parent()`
- [x] Lock `ChromoteSession$parent`
- [x] Lock `ChromoteSession$protocol`
- [x] Rename `Chromote$stop()` -> `Chromote$close()`

However...

`ChromoteSession` can not access the private events of `Chromote` or vice versa. `R6` objects do not inherit their `super`'s private methods.  This prevents moving many `self` helper methods to be `private` for both `Chromote` and `ChromoteSession` as they can not access each other's `private` methods. 

It _might_ be possible if R6 has access to `super_private` (or something similar), but it would not get rid of every method (`$mark_closed()`). 