### PR TITLE
Use a random port and set `--remote-allow-origins` to local host + port when launching chrome

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -140,7 +140,7 @@ launch_chrome_impl <- function(path, args, port) {
   if (!connected) {
     rlang::abort(
       "Chrome debugging port not open after 10 seconds.",
-      class = "error_timeout"
+      class = "error_stop_port_search"
     )
   }
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -86,56 +86,65 @@ launch_chrome <- function(path = find_chrome(), args = get_chrome_args()) {
     stop("Invalid path to Chrome")
   }
 
-  p <- process$new(
-    command = path,
-    args = c("--headless", "--remote-debugging-port=0", args),
-    supervise = TRUE,
-    stdout = tempfile("chrome-stdout-", fileext = ".log"),
-    stderr = tempfile("chrome-stderr-", fileext = ".log")
-  )
-
-
-  connected <- FALSE
-  end <- Sys.time() + 10
-  while (!connected && Sys.time() < end) {
-    if (!p$is_alive()) {
-      stop(
-        "Failed to start chrome. Error: ",
-        paste(readLines(p$get_error_file()), collapse = "\n")
-      )
-    }
-    tryCatch(
-      {
-        # Find port number from output
-        output <- readLines(p$get_error_file())
-        output <- output[grepl("^DevTools listening on ws://", output)]
-        if (length(output) != 1) stop() # Just break out of the tryCatch
-
-        port <- sub("^DevTools listening on ws://[0-9\\.]+:(\\d+)/.*", "\\1", output)
-        port <- as.integer(port)
-        if (is.na(port)) stop()
-
-        con <- url(paste0("http://127.0.0.1:", port, "/json/protocol"), "rb")
-        if (!isOpen(con)) break  # Failed to connect
-
-        connected <- TRUE
-        close(con)
-      },
-      warning = function(e) {},
-      error = function(e) {}
+  with_random_port(function(host, port) {
+    p <- process$new(
+      command = path,
+      args = c(
+        "--headless",
+        paste0("--remote-debugging-port=", port),
+        paste0("--remote-allow-origins=", host, ":", port),
+        args
+      ),
+      supervise = TRUE,
+      stdout = tempfile("chrome-stdout-", fileext = ".log"),
+      stderr = tempfile("chrome-stderr-", fileext = ".log")
     )
 
-    Sys.sleep(0.1)
-  }
+    connected <- FALSE
+    end <- Sys.time() + 10
+    while (!connected && Sys.time() < end) {
+      if (!p$is_alive()) {
+        stop(
+          "Failed to start chrome. Error: ",
+          paste(readLines(p$get_error_file()), collapse = "\n")
+        )
+      }
+      tryCatch(
+        {
+          # Find port number from output
+          output <- readLines(p$get_error_file())
+          output <- output[grepl("^DevTools listening on ws://", output)]
+          if (length(output) != 1) stop() # Just break out of the tryCatch
 
-  if (!connected) {
-    stop("Chrome debugging port not open after 10 seconds.")
-  }
+          output_port <- sub("^DevTools listening on ws://[0-9\\.]+:(\\d+)/.*", "\\1", output)
+          output_port <- as.integer(output_port)
+          if (is.na(output_port) || output_port != port) stop()
 
-  list(
-    process = p,
-    port    = port
-  )
+          con <- url(paste0("http://127.0.0.1:", port, "/json/protocol"), "rb")
+          if (!isOpen(con)) break  # Failed to connect
+
+          connected <- TRUE
+          close(con)
+        },
+        warning = function(e) {},
+        error = function(e) {}
+      )
+
+      Sys.sleep(0.1)
+    }
+
+    if (!connected) {
+      rlang::abort(
+        "Chrome debugging port not open after 10 seconds.",
+        class = "error_timeout"
+      )
+    }
+
+    list(
+      process = p,
+      port    = port
+    )
+  })
 }
 
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -86,13 +86,13 @@ launch_chrome <- function(path = find_chrome(), args = get_chrome_args()) {
     stop("Invalid path to Chrome")
   }
 
-  with_random_port(function(host, port) {
+  with_random_port(function(port) {
     p <- process$new(
       command = path,
       args = c(
         "--headless",
         paste0("--remote-debugging-port=", port),
-        paste0("--remote-allow-origins=", host, ":", port),
+        paste0("--remote-allow-origins=http://127.0.0.1:", port),
         args
       ),
       supervise = TRUE,

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,9 +119,9 @@ with_random_port <- function(
     # Try to run `.f()` with the random port
     res <- tryCatch(
       startup(host = host, port = port),
-      error = function(err) if (identical(port, ports[n])) err,
       error_timeout = identity,
-      system_command_error = identity
+      system_command_error = identity,
+      error = function(err) if (identical(port, ports[n])) err
     )
 
     if (rlang::cnd_inherits(res, "error")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,8 +104,7 @@ with_random_port <- function(
   startup,
   min = 1024L,
   max = 49151L,
-  n = 10,
-  host = "http://127.0.0.1"
+  n = 10
 ) {
   stopifnot(is.function(startup))
   valid_ports <- setdiff(seq.int(min, max), unsafe_ports)
@@ -118,7 +117,7 @@ with_random_port <- function(
 
     # Try to run `.f()` with the random port
     res <- tryCatch(
-      startup(host = host, port = port),
+      startup(port = port),
       error_timeout = identity,
       system_command_error = identity,
       error = function(err) if (identical(port, ports[n])) err

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,6 +102,7 @@ browse_url <- function(path, chromote) {
 
 with_random_port <- function(
   startup,
+  ...,
   min = 1024L,
   max = 49151L,
   n = 10
@@ -117,7 +118,7 @@ with_random_port <- function(
 
     # Try to run `.f()` with the random port
     res <- tryCatch(
-      startup(port = port),
+      startup(port = port, ...),
       error_timeout = identity,
       system_command_error = identity,
       error = function(err) if (identical(port, ports[n])) err

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,12 +101,13 @@ browse_url <- function(path, chromote) {
 # Borrowed from https://github.com/rstudio/httpuv/blob/main/R/random_port.R
 
 with_random_port <- function(
-  .f,
+  startup,
   min = 1024L,
   max = 49151L,
   n = 5,
   host = "http://127.0.0.1"
 ) {
+  stopifnot(is.function(startup))
   valid_ports <- setdiff(seq.int(min, max), unsafe_ports)
 
   # Try up to n ports
@@ -117,7 +118,7 @@ with_random_port <- function(
 
     # Try to run `.f()` with the random port
     res <- tryCatch(
-      .f(host = host, port = port),
+      startup(host = host, port = port),
       error = function(err) if (identical(port, ports[n])) err,
       error_timeout = identity,
       system_command_error = identity

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,3 +92,122 @@ browse_url <- function(path, chromote) {
     utils::browseURL(url)
   }
 }
+
+
+# =============================================================================
+# Random Ports
+# =============================================================================
+#
+# Borrowed from https://github.com/rstudio/httpuv/blob/main/R/random_port.R
+
+with_random_port <- function(
+  .f,
+  min = 1024L,
+  max = 49151L,
+  n = 5,
+  host = "http://127.0.0.1"
+) {
+  valid_ports <- setdiff(seq.int(min, max), unsafe_ports)
+
+  # Try up to n ports
+  n <- min(n, length(valid_ports))
+  ports <- sample(valid_ports, n)
+  for (port in ports) {
+    res <- NULL
+
+    # Try to run `.f()` with the random port
+    res <- tryCatch(
+      .f(host = host, port = port),
+      error = function(err) if (identical(port, ports[n])) err,
+      error_timeout = identity,
+      system_command_error = identity
+    )
+
+    if (rlang::cnd_inherits(res, "error")) {
+      # A timeout error or trying all ports is unlikely to be port-related problem
+      rlang::cnd_signal(res)
+    }
+
+    if (!is.null(res)) {
+      return(res)
+    }
+  }
+
+  rlang::abort(
+    "Cannot find an available port. Please try again.",
+    class = "chromote_error_no_available_port"
+  )
+}
+
+# Ports that are considered unsafe by Chrome
+# http://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+# https://github.com/rstudio/shiny/issues/1784
+unsafe_ports <- c(
+  1,
+  7,
+  9,
+  11,
+  13,
+  15,
+  17,
+  19,
+  20,
+  21,
+  22,
+  23,
+  25,
+  37,
+  42,
+  43,
+  53,
+  77,
+  79,
+  87,
+  95,
+  101,
+  102,
+  103,
+  104,
+  109,
+  110,
+  111,
+  113,
+  115,
+  117,
+  119,
+  123,
+  135,
+  139,
+  143,
+  179,
+  389,
+  427,
+  465,
+  512,
+  513,
+  514,
+  515,
+  526,
+  530,
+  531,
+  532,
+  540,
+  548,
+  556,
+  563,
+  587,
+  601,
+  636,
+  993,
+  995,
+  2049,
+  3659,
+  4045,
+  6000,
+  6665,
+  6666,
+  6667,
+  6668,
+  6669,
+  6697
+)

--- a/R/utils.R
+++ b/R/utils.R
@@ -107,8 +107,7 @@ browse_url <- function(path, chromote) {
 #'   value that will also be returned from `with_random_port()`. Generic errors
 #'   emitted by this function are silently ignored: when `startup()` fails, we
 #'   assume the port was unavailable and we try with a new port. Errors with the
-#'   classes `error_timeout`, `error_no_port_retry` and `system_command_error`
-#'   fail immediately.
+#'   classes `error_stop_port_search` and `system_command_error` fail immediately.
 #' @param ... Additional arguments passed to `startup()`.
 #' @param min,max Port range
 #' @param n Maximum number of ports to try
@@ -139,9 +138,8 @@ with_random_port <- function(
         res <- startup(port = port, ...)
       },
       # Non generic errors that signal we should stop trying new ports
-      error_timeout = function(cnd) err <<- cnd,
       system_command_error = function(cnd) err <<- cnd,
-      error_no_port_retry = function(cnd) err <<- cnd,
+      error_stop_port_search = function(cnd) err <<- cnd,
       # For other errors, they are probably because the port is already in use.
       # Don't do anything; we'll just continue in the loop, but we save the
       # last port retry error to throw in case it's informative.

--- a/R/utils.R
+++ b/R/utils.R
@@ -100,6 +100,21 @@ browse_url <- function(path, chromote) {
 #
 # Borrowed from https://github.com/rstudio/httpuv/blob/main/R/random_port.R
 
+#' Startup a service that requires a random port
+#'
+#' @param startup A function that takes a `port` argument, where `port` will be
+#'   randomly selected. When successful, `startup()` should return a non-NULL
+#'   value that will also be returned from `with_random_port()`. Generic errors
+#'   emitted by this function are silently ignored: when `startup()` fails, we
+#'   assume the port was unavailable and we try with a new port. Errors with the
+#'   classes `error_timeout`, `error_no_port_retry` and `system_command_error`
+#'   fail immediately.
+#' @param ... Additional arguments passed to `startup()`.
+#' @param min,max Port range
+#' @param n Maximum number of ports to try
+#'
+#' @return The result of `startup()`, or an error if `startup()` fails.
+#' @noRd
 with_random_port <- function(
   startup,
   ...,

--- a/R/utils.R
+++ b/R/utils.R
@@ -143,15 +143,15 @@ with_random_port <- function(
   ports <- sample(valid_ports, n)
   err_port <- NULL
 
-  .empty_result <- structure(list(), class = "no value returned from startup")
-
   for (port in ports) {
-    res <- .empty_result
+    success <- FALSE
+    res <- NULL
     err_fatal <- NULL
 
     # Try to run `startup` with the random port
     tryCatch({
         res <- startup(port = port, ...)
+        success <- TRUE
       },
       error = function(cnd) {
         if (rlang::cnd_inherits(cnd, stop_on)) {
@@ -171,7 +171,7 @@ with_random_port <- function(
       rlang::cnd_signal(err_fatal)
     }
 
-    if (!inherits(res, "no value returned from startup")) {
+    if (isTRUE(success)) {
       return(res)
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,7 +104,7 @@ with_random_port <- function(
   startup,
   min = 1024L,
   max = 49151L,
-  n = 5,
+  n = 10,
   host = "http://127.0.0.1"
 ) {
   stopifnot(is.function(startup))

--- a/R/utils.R
+++ b/R/utils.R
@@ -105,7 +105,7 @@ browse_url <- function(path, chromote) {
 #' `with_random_port()` provides `startup()` with a random port value and runs
 #' the function:
 #'
-#' 1. `startup()` always returns a (non-`NULL`) value if successful
+#' 1. `startup()` always returns a value if successful.
 #' 2. If `startup()` fails with a generic error, we assume the port is occupied
 #'    and try the next random port.
 #' 3. If `startup()` fails with an error classed with `error_stop_port_search`
@@ -141,8 +141,10 @@ with_random_port <- function(
   ports <- sample(valid_ports, n)
   err_port <- NULL
 
+  .empty_result <- structure(list(), class = "no value returned from startup")
+
   for (port in ports) {
-    res <- NULL
+    res <- .empty_result
     err <- NULL
 
     # Try to run `startup` with the random port
@@ -162,7 +164,7 @@ with_random_port <- function(
       rlang::cnd_signal(err)
     }
 
-    if (!is.null(res)) {
+    if (!inherits(res, "no value returned from startup")) {
       return(res)
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,6 +123,7 @@ with_random_port <- function(
       },
       error_timeout = function(cnd) err <<- cnd,
       system_command_error = function(cnd) err <<- cnd,
+      error_no_port_retry = function(cnd) err <<- cnd,
       # For other errors, they are probably because the port is already in use.
       # Don't do anything; we'll just continue in the loop.
       error = function(e) NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,6 +102,18 @@ browse_url <- function(path, chromote) {
 
 #' Startup a service that requires a random port
 #'
+#' `with_random_port()` provides `startup()` with a random port value and runs
+#' the function:
+#'
+#' 1. `startup()` always returns a (non-`NULL`) value if successful
+#' 2. If `startup()` fails with a generic error, we assume the port is occupied
+#'    and try the next random port.
+#' 3. If `startup()` fails with an error classed with `error_stop_port_search`
+#'    or `system_command_error`, we stop the port search and rethrow the fatal
+#'    error.
+#' 4. If we try `n` random ports, the port search stops with an informative
+#'    error that includes the last port attempt error.
+#'
 #' @param startup A function that takes a `port` argument, where `port` will be
 #'   randomly selected. When successful, `startup()` should return a non-NULL
 #'   value that will also be returned from `with_random_port()`. Generic errors

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -62,3 +62,12 @@ test_that("with_random_port() returns result of `startup()`", {
     expect_true(all(tried_ports %% 5 > 0))
   }
 })
+
+test_that("with_random_port() startup function can return NULL", {
+  accept_any_port <- function(port) {
+    NULL
+  }
+
+  port <- with_random_port(accept_any_port)
+  expect_null(port)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,64 @@
+test_that("with_random_port() tries expected number of ports in range", {
+  min <- 2000L
+  max <- 4000L
+  n <- 25
+
+  tried_ports <- c()
+
+  try_unavailable_port <- function(port) {
+    tried_ports <<- c(tried_ports, port)
+    stop("Port ", port, " is unavailable.")
+  }
+
+  expect_error(
+    with_random_port(
+      try_unavailable_port,
+      min = min,
+      max = max,
+      n = n
+    )
+  )
+
+  expect_length(tried_ports, n)
+  expect_true(all(tried_ports >= min))
+  expect_true(all(tried_ports <= max))
+})
+
+test_that("with_random_port() stops trying for `error_stop_port_search` errors", {
+  tried_ports <- c()
+
+  try_port_with_fatal_error <- function(port) {
+    tried_ports <<- c(tried_ports, port)
+    rlang::abort(
+      paste0("Port ", port, " is unavailable."),
+      class = "error_stop_port_search"
+    )
+  }
+
+  expect_error(
+    with_random_port(try_port_with_fatal_error),
+    class = "error_stop_port_search"
+  )
+  expect_length(tried_ports, 1)
+})
+
+test_that("with_random_port() returns result of `startup()`", {
+  tried_ports <- c()
+
+  accept_round_port <- function(port) {
+    if (port %% 5 == 0) {
+      return(port)
+    }
+
+    tried_ports <<- c(tried_ports, port)
+    stop("Odd port")
+  }
+
+  port <- with_random_port(accept_round_port, n = 100)
+
+  expect_true(port %% 5 == 0)
+
+  if (length(tried_ports)) {
+    expect_true(all(tried_ports %% 5 > 0))
+  }
+})


### PR DESCRIPTION
This is an alternative fix to #99 and #100. I borrowed heavily from [httpuv::random_port()](https://github.com/rstudio/httpuv/blob/main/R/random_port.R) with a few big differences (since starting up chromote isn't quite as simple as starting up a short-lived http server) that I'll call out briefly.

* I've added `with_random_port()` that follows the logic of `random_port()` but accepts a `startup` function. This function should take `port` and `host` (although `host` defaults to `http://127.0.0.1`) and is called with a random port.
* The function either fails or returns a non-null value, in which case we assume we've successfully found an open port. There are four possible next steps for a failure:
  1. For a generic error, if we haven't exhausted the `n` tries, we try `startup()` again with a new port.
  2. If we receive a generic error but have exhausted the `n` tries, we rethrow the error. I've reduced the number of ports to try to 5 for chromote, but we may want another default (or to make the value configurable via an option?).
  3. If we receive a timeout error with class `error_timeout`, we rethrow the error without trying additional ports. In `launch_chrome()`, this error happens when the chrome process is running but hangs.
  4. If we receive a `system_command_error` error, we rethrow the error without trying additional ports. The goal here is to catch generic `processx::process` errors that indicate that a lower-level fatal error has occurred.

Beyond the random port selection, this PR solves the issue in #99 by setting `--remote-debugging-port={known_port}` and pairing that with `--remote-allow-origins=https://127.0.0.1:{known_port}`.

Fixes #99
Closes #100 