### PR TITLE
Better message from `find_chrome` on Windows when Chrome not found.

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -55,7 +55,7 @@ find_chrome <- function() {
         path <- path[["(Default)"]]
       },
       error = function(e) {
-        message("Error trying to find path to Chrome")
+        message("Google Chrome was not found. Set the CHROMOTE_CHROME environment variable to the executable of a Chromium-based browser, such as Google Chrome, Chromium or Brave.")
         path <<- NULL
       }
     )


### PR DESCRIPTION
Adresses #108. Better message from `find_chrome` on Windows when Google Chrome is not found.