### PR TITLE
Check in more places for Chrome on Linux and Mac

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Fixed #99: When the `$view()` method was called, recent versions of Chrome would display `"Debugging connection was closed. Reason: WebSocket disconnected"`. (#101)
 
-* Fixed #89: `find_chrome()` now checks more possible binary names for Chrome or Chromium on Linux. (thanks @brianmsm, #117)
+* Fixed #89, #91: `find_chrome()` now checks more possible binary names for Chrome or Chromium on Linux and Mac. (thanks @brianmsm and @rossellhayes, #117)
 
 
 # chromote 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed #99: When the `$view()` method was called, recent versions of Chrome would display `"Debugging connection was closed. Reason: WebSocket disconnected"`. (#101)
 
+* Fixed #89: `find_chrome()` now checks more possible binary names for Chrome or Chromium on Linux. (thanks @brianmsm, #117)
+
 
 # chromote 0.1.1
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -61,17 +61,7 @@ find_chrome <- function() {
     )
 
   } else if (is_linux()) {
-    path <- Sys.which("google-chrome")
-    if (nchar(path) == 0) {
-      path <- Sys.which("chromium-browser")
-    }
-    if (nchar(path) == 0) {
-      path <- Sys.which("chromium")
-    }
-    if (nchar(path) == 0) {
-      message("`google-chrome` and `chromium-browser` were not found. Try setting the CHROMOTE_CHROME environment variable or adding one of these executables to your PATH.")
-      path <- NULL
-    }
+    path <- find_chrome_linux()
 
   } else {
     message("Platform currently not supported")
@@ -80,6 +70,27 @@ find_chrome <- function() {
   path
 }
 
+find_chrome_linux <- function() {
+  possible_names <- c(
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium-browser",
+    "chromium",
+    "google-chrome-beta",
+    "google-chrome-unstable"
+  )
+
+  for (path in possible_names) {
+    path <- Sys.which(path)
+    if (nzchar(path)) {
+      return(path)
+    }
+  }
+
+  message("`google-chrome` and `chromium-browser` were not found. Try setting the CHROMOTE_CHROME environment variable or adding one of these executables to your PATH.")
+
+  NULL
+}
 
 launch_chrome <- function(path = find_chrome(), args = get_chrome_args()) {
   if (is.null(path)) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -43,8 +43,6 @@ find_chrome <- function() {
     return(Sys.getenv("CHROMOTE_CHROME"))
   }
 
-  path <- NULL
-
   path <-
     if (is_mac()) {
       inform_if_chrome_not_found(find_chrome_mac())


### PR DESCRIPTION
Fixes #89
Fixes #91
Closes #90

I refactored the checks a bit so that they share logic:

* `find_chrome_{windows,mac,linux}()` looks for the path in common places and returns any if found
* `inform_if_chrome_not_found()` returns the path if found or returns NULL with an informative message if it isn't found