### PR TITLE
docs(find_chrome): Improve docs

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -57,11 +57,11 @@ Chrome <- R6Class("Chrome",
 #' )
 #' ```
 #'
-#' When `CHROMOTE_CHROME` is not set, `find_chrome()` will attempt to find a
-#' reasonable executable. On Windows, `find_chrome()` consults the registry to
-#' find `chrome.exe`. On Mac, it looks for `Google Chrome` in the
-#' `/Applications` folder (or tries the same checks as on Linux). On Linux, it
-#' searches for several common executable names.
+#' When `CHROMOTE_CHROME` is not set, `find_chrome()` will perform a limited
+#' search to find a reasonable executable. On Windows, `find_chrome()` consults
+#' the registry to find `chrome.exe`. On Mac, it looks for `Google Chrome` in
+#' the `/Applications` folder (or tries the same checks as on Linux). On Linux,
+#' it searches for several common executable names.
 #'
 #' @examples
 #' find_chrome()

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -53,7 +53,7 @@ Chrome <- R6Class("Chrome",
 #'
 #' ```r
 #' Sys.setenv(
-#'   CHROMOTE_CHROME = "/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge"
+#'   CHROMOTE_CHROME = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 #' )
 #' ```
 #'

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -37,6 +37,39 @@ Chrome <- R6Class("Chrome",
 )
 
 #' Find path to Chrome or Chromium browser
+#'
+#' @description
+#' \pkg{chromote} requires a Chrome- or Chromium-based browser with support for
+#' the Chrome DevTools Protocol. There are many such browser variants,
+#' including [Google Chrome](https://www.google.com/chrome/),
+#' [Chromium](https://www.chromium.org/chromium-projects/),
+#' [Microsoft Edge](https://www.microsoft.com/en-us/edge/) and others.
+#'
+#' If you want \pkg{chromote} to use a specific browser, set the
+#' `CHROMOTE_CHROME` environment variable to the full path to the browser's
+#' executable. Note that when `CHROMOTE_CHROME` is set, \pkg{chromote} will use
+#' the value without any additional checks. On Mac, for example, one could use
+#' Microsoft Edge by setting `CHROMOTE_CHROME` with the following:
+#'
+#' ```r
+#' Sys.setenv(
+#'   CHROMOTE_CHROME = "/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge"
+#' )
+#' ```
+#'
+#' When `CHROMOTE_CHROME` is not set, `find_chrome()` will attempt to find a
+#' reasonable executable. On Windows, `find_chrome()` consults the registry to
+#' find `chrome.exe`. On Mac, it looks for `Google Chrome` in the
+#' `/Applications` folder (or tries the same checks as on Linux). On Linux, it
+#' searches for several common executable names.
+#'
+#' @examples
+#' find_chrome()
+#'
+#' @returns A character vector with the value of `CHROMOTE_CHROME`, or a path to
+#'   the discovered Chrome executable. If no path to is found, `find_chrome()`
+#'   returns `NULL`.
+#'
 #' @export
 find_chrome <- function() {
   if (Sys.getenv("CHROMOTE_CHROME") != "") {

--- a/man/find_chrome.Rd
+++ b/man/find_chrome.Rd
@@ -25,7 +25,7 @@ the value without any additional checks. On Mac, for example, one could use
 Microsoft Edge by setting \code{CHROMOTE_CHROME} with the following:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{Sys.setenv(
-  CHROMOTE_CHROME = "/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge"
+  CHROMOTE_CHROME = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 )
 }\if{html}{\out{</div>}}
 

--- a/man/find_chrome.Rd
+++ b/man/find_chrome.Rd
@@ -6,6 +6,36 @@
 \usage{
 find_chrome()
 }
+\value{
+A character vector with the value of \code{CHROMOTE_CHROME}, or a path to
+the discovered Chrome executable. If no path to is found, \code{find_chrome()}
+returns \code{NULL}.
+}
 \description{
-Find path to Chrome or Chromium browser
+\pkg{chromote} requires a Chrome- or Chromium-based browser with support for
+the Chrome DevTools Protocol. There are many such browser variants,
+including \href{https://www.google.com/chrome/}{Google Chrome},
+\href{https://www.chromium.org/chromium-projects/}{Chromium},
+\href{https://www.microsoft.com/en-us/edge/}{Microsoft Edge} and others.
+
+If you want \pkg{chromote} to use a specific browser, set the
+\code{CHROMOTE_CHROME} environment variable to the full path to the browser's
+executable. Note that when \code{CHROMOTE_CHROME} is set, \pkg{chromote} will use
+the value without any additional checks. On Mac, for example, one could use
+Microsoft Edge by setting \code{CHROMOTE_CHROME} with the following:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{Sys.setenv(
+  CHROMOTE_CHROME = "/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge"
+)
+}\if{html}{\out{</div>}}
+
+When \code{CHROMOTE_CHROME} is not set, \code{find_chrome()} will attempt to find a
+reasonable executable. On Windows, \code{find_chrome()} consults the registry to
+find \code{chrome.exe}. On Mac, it looks for \verb{Google Chrome} in the
+\verb{/Applications} folder (or tries the same checks as on Linux). On Linux, it
+searches for several common executable names.
+}
+\examples{
+find_chrome()
+
 }

--- a/man/find_chrome.Rd
+++ b/man/find_chrome.Rd
@@ -29,11 +29,11 @@ Microsoft Edge by setting \code{CHROMOTE_CHROME} with the following:
 )
 }\if{html}{\out{</div>}}
 
-When \code{CHROMOTE_CHROME} is not set, \code{find_chrome()} will attempt to find a
-reasonable executable. On Windows, \code{find_chrome()} consults the registry to
-find \code{chrome.exe}. On Mac, it looks for \verb{Google Chrome} in the
-\verb{/Applications} folder (or tries the same checks as on Linux). On Linux, it
-searches for several common executable names.
+When \code{CHROMOTE_CHROME} is not set, \code{find_chrome()} will perform a limited
+search to find a reasonable executable. On Windows, \code{find_chrome()} consults
+the registry to find \code{chrome.exe}. On Mac, it looks for \verb{Google Chrome} in
+the \verb{/Applications} folder (or tries the same checks as on Linux). On Linux,
+it searches for several common executable names.
 }
 \examples{
 find_chrome()


### PR DESCRIPTION
Adds documentation to `find_chrome()`. In particular will help users discover the `CHROMOTE_CHROME` environment variable and better understand its limitations.

Fixes #108 (technically fixed by #117, but this also addresses a coment there)