### PR TITLE
docs: Make examples static

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -276,14 +276,18 @@ Chromote <- R6Class(
     #' @description
     #' Submit debug log message
     #'
-    #' @param ... Arguments pasted together with `paste0(..., collapse = "")`.
-    #' @examples
-    #' \dontrun{b <- ChromoteSession$new()
+    #' ## Examples
+    #'
+    #' ```r
+    #' b <- ChromoteSession$new()
     #' b$parent$debug_messages(TRUE)
     #' b$Page$navigate("https://www.r-project.org/")
     #' #> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
     #' # Turn off debug messages
-    #' b$parent$debug_messages(FALSE)}
+    #' b$parent$debug_messages(FALSE)
+    #' ```
+    #'
+    #' @param ... Arguments pasted together with `paste0(..., collapse = "")`.
     debug_log = function(...) {
       txt <- truncate(paste0(..., collapse = ""), 1000)
       if (private$debug_messages_) {

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -26,6 +26,23 @@ ChromoteSession <- R6Class(
   cloneable = FALSE,
   public = list(
     #' @description Create a new `ChromoteSession` object.
+    #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' # Create a new `ChromoteSession` object.
+    #' b <- ChromoteSession$new()
+    #'
+    #' # Create a ChromoteSession with a specific height,width
+    #' b <- ChromoteSession$new(height = 1080, width = 1920)
+    #'
+    #' # Navigate to page
+    #' b$Page$navigate("http://www.r-project.org/")
+    #'
+    #' # View current chromote session
+    #' if (interactive()) b$view()
+    #' ```
+    #'
     #' @param parent [`Chromote`] object to use; defaults to
     #'   [default_chromote_object()]
     #' @param auto_events If `NULL` (the default), use the `auto_events` setting
@@ -36,18 +53,6 @@ ChromoteSession <- R6Class(
     #'   `ChromoteSession` object. Otherwise, block during initialization, and
     #'   return a `ChromoteSession` object directly.
     #' @return A new `ChromoteSession` object.
-    #' @examples
-    #' \dontrun{# Create a new `ChromoteSession` object.
-    #' b <- ChromoteSession$new()
-    #'
-    #' # Create a ChromoteSession with a specific height,width
-    #' b <- ChromoteSession$new(height = 1080, width = 1920)
-    #'
-    #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
-    #'
-    #' # View current chromote session
-    #' if (interactive()) b$view()}
     initialize = function(
       parent = default_chromote_object(),
       width = 992,
@@ -138,15 +143,19 @@ ChromoteSession <- R6Class(
     #' If a [`Chrome`] browser is being used, this method will open a new tab
     #' using your [`Chrome`] browser. When not using a [`Chrome`] browser, set
     #' `options(browser=)` to change the default behavior of [`browseURL()`].
-    #' @examples
-    #' \dontrun{# Create a new `ChromoteSession` object.
+    #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' # Create a new `ChromoteSession` object.
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
     #' b$Page$navigate("http://www.r-project.org/")
     #'
     #' # View current chromote session
-    #' if (interactive()) b$view()}
+    #' if (interactive()) b$view()
+    #' ```
     view = function() {
       tid <- self$Target$getTargetInfo()$targetInfo$targetId
 
@@ -161,18 +170,23 @@ ChromoteSession <- R6Class(
     },
 
     #' @description Close the Chromote session.
-    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
-    #' when the `ChromoteSession` is closed. Otherwise, block until the
-    #' `ChromoteSession` has closed.
-    #' @examples
-    #' \dontrun{# Create a new `ChromoteSession` object.
+    #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' # Create a new `ChromoteSession` object.
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
     #' b$Page$navigate("http://www.r-project.org/")
     #'
     #' # Close current chromote session
-    #' b$close()}
+    #' b$close()
+    #' ```
+    #'
+    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
+    #' when the `ChromoteSession` is closed. Otherwise, block until the
+    #' `ChromoteSession` has closed.
     close = function(wait_ = TRUE) {
       p <- self$Target$getTargetInfo(wait_ = FALSE)
       p <- p$then(function(target) {
@@ -199,25 +213,10 @@ ChromoteSession <- R6Class(
 
     #' @description Take a PNG screenshot
     #'
-    #' @param filename File path of where to save the screenshot.
-    #' @param selector CSS selector to use for the screenshot.
-    #' @param cliprect A list containing `x`, `y`, `width`, and `height`. See
-    #' [`Page.Viewport`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-Viewport)
-    #' for more information. If provided, `selector` and `expand` will be
-    #' ignored. To provide a scale, use the `scale` parameter.
-    #' @param region CSS region to use for the screenshot.
-    #' @param expand Extra pixels to expand the screenshot. May be a single
-    #' value or a numeric vector of top, right, bottom, left values.
-    #' @param scale Page scale factor
-    #' @param show If `TRUE`, the screenshot will be displayed in the viewer.
-    #' @param delay The number of seconds to wait before taking the screenshot
-    #' after resizing the page. For complicated pages, this may need to be
-    #' increased.
-    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
-    #' when the `ChromoteSession` has saved the screenshot. Otherwise, block
-    #' until the `ChromoteSession` has saved the screenshot.
-    #' @examples
-    #' \dontrun{# Create a new `ChromoteSession` object.
+    #' ## Examples
+    #'
+    #' ```r
+    #' # Create a new `ChromoteSession` object.
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
@@ -284,7 +283,26 @@ ChromoteSession <- R6Class(
     #' #> www_r-project_org.png
     #' #> github_com.png
     #' #> news_ycombinator_com.png
-    #' #> Done!}
+    #' #> Done!
+    #' ```
+    #'
+    #' @param filename File path of where to save the screenshot.
+    #' @param selector CSS selector to use for the screenshot.
+    #' @param cliprect A list containing `x`, `y`, `width`, and `height`. See
+    #' [`Page.Viewport`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-Viewport)
+    #' for more information. If provided, `selector` and `expand` will be
+    #' ignored. To provide a scale, use the `scale` parameter.
+    #' @param region CSS region to use for the screenshot.
+    #' @param expand Extra pixels to expand the screenshot. May be a single
+    #' value or a numeric vector of top, right, bottom, left values.
+    #' @param scale Page scale factor
+    #' @param show If `TRUE`, the screenshot will be displayed in the viewer.
+    #' @param delay The number of seconds to wait before taking the screenshot
+    #' after resizing the page. For complicated pages, this may need to be
+    #' increased.
+    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
+    #' when the `ChromoteSession` has saved the screenshot. Otherwise, block
+    #' until the `ChromoteSession` has saved the screenshot.
     screenshot = function(
       filename = "screenshot.png",
       selector = "html",
@@ -312,6 +330,23 @@ ChromoteSession <- R6Class(
 
     #' @description Take a PDF screenshot
     #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' # Create a new `ChromoteSession` object.
+    #' b <- ChromoteSession$new()
+    #'
+    #' # Navigate to page
+    #' b$Page$navigate("http://www.r-project.org/")
+    #'
+    #' # Take screenshot
+    #' tmppdffile <- tempfile(fileext = ".pdf")
+    #' b$screenshot_pdf(tmppdffile)
+    #'
+    #' # Show PDF file info
+    #' unlist(file.info(tmppdffile))
+    #' ```
+    #'
     #' @param filename File path of where to save the screenshot.
     #' @param pagesize A single character value in the set `"letter"`,
     #' `"legal"`, `"tabloid"`, `"ledger"` and `"a0"` through `"a1"`. Or a
@@ -327,19 +362,6 @@ ChromoteSession <- R6Class(
     #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
     #' when the `ChromoteSession` has saved the screenshot. Otherwise, block
     #' until the `ChromoteSession` has saved the screnshot.
-    #' @examples
-    #' \dontrun{# Create a new `ChromoteSession` object.
-    #' b <- ChromoteSession$new()
-    #'
-    #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
-    #'
-    #' # Take screenshot
-    #' tmppdffile <- tempfile(fileext = ".pdf")
-    #' b$screenshot_pdf(tmppdffile)
-    #'
-    #' # Show PDF file info
-    #' unlist(file.info(tmppdffile))}
     screenshot_pdf = function(
       filename = "screenshot.pdf",
       pagesize = "letter",
@@ -367,29 +389,37 @@ ChromoteSession <- R6Class(
 
     #' @description Create a new tab / window
     #'
-    #' @param width,height Width and height of the new window.
-    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
-    #' when the `ChromoteSession` has created a new session. Otherwise, block
-    #' until the `ChromoteSession` has created a new session.
-    #' @examples
-    #' \dontrun{b1 <- ChromoteSession$new()
+    #' ## Examples
+    #'
+    #' ```r
+    #' b1 <- ChromoteSession$new()
     #' b1$Page$navigate("http://www.google.com")
     #' b2 <- b1$new_session()
     #' b2$Page$navigate("http://www.r-project.org/")
     #' b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
     #' #> [1] "https://www.google.com/"
     #' b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
-    #' #> [1] "https://www.r-project.org/"}
+    #' #> [1] "https://www.r-project.org/"
+    #' ```
+    #'
+    #' @param width,height Width and height of the new window.
+    #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
+    #' when the `ChromoteSession` has created a new session. Otherwise, block
+    #' until the `ChromoteSession` has created a new session.
     new_session = function(width = 992, height = 1323, targetId = NULL, wait_ = TRUE) {
       self$parent$new_session(width = width, height = height, targetId = targetId, wait_ = wait_)
     },
 
     #' @description
     #' Retrieve the session id
-    #' @examples
-    #' \dontrun{b <- ChromoteSession$new()
+    #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' b <- ChromoteSession$new()
     #' b$get_session_id()
-    #' #> [1] "05764F1D439F4292497A21C6526575DA"}
+    #' #> [1] "05764F1D439F4292497A21C6526575DA"
+    #' ```
     get_session_id = function() {
       private$session_id
     },
@@ -399,16 +429,21 @@ ChromoteSession <- R6Class(
     #' session until the provided promise resolves. The loop from
     #' `$get_child_loop()` will only advance just far enough for the promise to
     #' resolve.
-    #' @param p A promise to resolve.
-    #' @examples
-    #' \dontrun{b <- ChromoteSession$new()
+    #'
+    #' ## Examples
+    #'
+    #' ```r
+    #' b <- ChromoteSession$new()
     #'
     #' # Async with promise
     #' p <- b$Browser$getVersion(wait_ = FALSE)
     #' p$then(str)
     #'
     #' # Async with callback
-    #' b$Browser$getVersion(wait_ = FALSE, callback_ = str)}
+    #' b$Browser$getVersion(wait_ = FALSE, callback_ = str)
+    #' ```
+    #'
+    #' @param p A promise to resolve.
     wait_for = function(p) {
       self$parent$wait_for(p)
     },
@@ -416,14 +451,18 @@ ChromoteSession <- R6Class(
     #' @description
     #' Send a debug log message to the parent [Chromote] object
     #'
-    #' @param ... Arguments pasted together with `paste0(..., collapse = "")`.
-    #' @examples
-    #' \dontrun{b <- ChromoteSession$new()
+    #' ## Examples
+    #'
+    #' ```r
+    #' b <- ChromoteSession$new()
     #' b$parent$debug_messages(TRUE)
     #' b$Page$navigate("https://www.r-project.org/")
     #' #> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
     #' # Turn off debug messages
-    #' b$parent$debug_messages(FALSE)}
+    #' b$parent$debug_messages(FALSE)
+    #' ```
+    #'
+    #' @param ... Arguments pasted together with `paste0(..., collapse = "")`.
     debug_log = function(...) {
       self$parent$debug_log(...)
     },

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -30,19 +30,6 @@ calls to \code{ChromoteSession$new()} will automatically use the same \code{Chro
 This is so that it doesn't start a new browser for every \code{ChromoteSession}
 object that is created.
 }
-\examples{
-
-## ------------------------------------------------
-## Method `Chromote$debug_log`
-## ------------------------------------------------
-
-\dontrun{b <- ChromoteSession$new()
-b$parent$debug_messages(TRUE)
-b$Page$navigate("https://www.r-project.org/")
-#> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
-# Turn off debug messages
-b$parent$debug_messages(FALSE)}
-}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -293,6 +280,16 @@ If enabled, R will print out the
 \if{latex}{\out{\hypertarget{method-Chromote-debug_log}{}}}
 \subsection{Method \code{debug_log()}}{
 Submit debug log message
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
+b$parent$debug_messages(TRUE)
+b$Page$navigate("https://www.r-project.org/")
+#> SEND \{"method":"Page.navigate","params":\{"url":"https://www.r-project.org/"\}| __truncated__\}
+# Turn off debug messages
+b$parent$debug_messages(FALSE)
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$debug_log(...)}\if{html}{\out{</div>}}
 }
@@ -304,19 +301,6 @@ Submit debug log message
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{b <- ChromoteSession$new()
-b$parent$debug_messages(TRUE)
-b$Page$navigate("https://www.r-project.org/")
-#> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
-# Turn off debug messages
-b$parent$debug_messages(FALSE)}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chromote-url"></a>}}

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -8,185 +8,6 @@ ChromoteSession class
 
 ChromoteSession class
 }
-\examples{
-
-## ------------------------------------------------
-## Method `ChromoteSession$new`
-## ------------------------------------------------
-
-\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Create a ChromoteSession with a specific height,width
-b <- ChromoteSession$new(height = 1080, width = 1920)
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# View current chromote session
-if (interactive()) b$view()}
-
-## ------------------------------------------------
-## Method `ChromoteSession$view`
-## ------------------------------------------------
-
-\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# View current chromote session
-if (interactive()) b$view()}
-
-## ------------------------------------------------
-## Method `ChromoteSession$close`
-## ------------------------------------------------
-
-\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Close current chromote session
-b$close()}
-
-## ------------------------------------------------
-## Method `ChromoteSession$screenshot`
-## ------------------------------------------------
-
-\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Take screenshot
-tmppngfile <- tempfile(fileext = ".png")
-is_interactive <- interactive() # Display screenshot if interactive
-b$screenshot(tmppngfile, show = is_interactive)
-
-# Show screenshot file info
-unlist(file.info(tmppngfile))
-
-
-# Take screenshot using a selector
-sidebar_file <- tempfile(fileext = ".png")
-b$screenshot(sidebar_file, selector = ".sidebar", show = is_interactive)
-
-# ----------------------------
-# Take screenshots in parallel
-
-urls <- c(
-  "https://www.r-project.org/",
-  "https://github.com/",
-  "https://news.ycombinator.com/"
-)
-# Helper method that:
-# 1. Navigates to the given URL
-# 2. Waits for the page loaded event to fire
-# 3. Takes a screenshot
-# 4. Prints a message
-# 5. Close the ChromoteSession
-screenshot_p <- function(url, filename = NULL) {
-  if (is.null(filename)) {
-    filename <- gsub("^.*://", "", url)
-    filename <- gsub("/", "_", filename)
-    filename <- gsub("\\\\.", "_", filename)
-    filename <- sub("_$", "", filename)
-    filename <- paste0(filename, ".png")
-  }
-
-  b2 <- b$new_session()
-  b2$Page$navigate(url, wait_ = FALSE)
-  b2$Page$loadEventFired(wait_ = FALSE)$
-    then(function(value) {
-      b2$screenshot(filename, wait_ = FALSE)
-    })$
-    then(function(value) {
-      message(filename)
-    })$
-    finally(function() {
-      b2$close()
-    })
-}
-
-# Take multiple screenshots simultaneously
-ps <- lapply(urls, screenshot_p)
-pa <- promises::promise_all(.list = ps)$then(function(value) {
-  message("Done!")
-})
-
-# Block the console until the screenshots finish (optional)
-b$wait_for(pa)
-#> www_r-project_org.png
-#> github_com.png
-#> news_ycombinator_com.png
-#> Done!}
-
-## ------------------------------------------------
-## Method `ChromoteSession$screenshot_pdf`
-## ------------------------------------------------
-
-\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Take screenshot
-tmppdffile <- tempfile(fileext = ".pdf")
-b$screenshot_pdf(tmppdffile)
-
-# Show PDF file info
-unlist(file.info(tmppdffile))}
-
-## ------------------------------------------------
-## Method `ChromoteSession$new_session`
-## ------------------------------------------------
-
-\dontrun{b1 <- ChromoteSession$new()
-b1$Page$navigate("http://www.google.com")
-b2 <- b1$new_session()
-b2$Page$navigate("http://www.r-project.org/")
-b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
-#> [1] "https://www.google.com/"
-b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
-#> [1] "https://www.r-project.org/"}
-
-## ------------------------------------------------
-## Method `ChromoteSession$get_session_id`
-## ------------------------------------------------
-
-\dontrun{b <- ChromoteSession$new()
-b$get_session_id()
-#> [1] "05764F1D439F4292497A21C6526575DA"}
-
-## ------------------------------------------------
-## Method `ChromoteSession$wait_for`
-## ------------------------------------------------
-
-\dontrun{b <- ChromoteSession$new()
-
-# Async with promise
-p <- b$Browser$getVersion(wait_ = FALSE)
-p$then(str)
-
-# Async with callback
-b$Browser$getVersion(wait_ = FALSE, callback_ = str)}
-
-## ------------------------------------------------
-## Method `ChromoteSession$debug_log`
-## ------------------------------------------------
-
-\dontrun{b <- ChromoteSession$new()
-b$parent$debug_messages(TRUE)
-b$Page$navigate("https://www.r-project.org/")
-#> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
-# Turn off debug messages
-b$parent$debug_messages(FALSE)}
-}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -225,6 +46,21 @@ wait for a Chrome DevTools Protocol response.}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new \code{ChromoteSession} object.
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Create a new `ChromoteSession` object.
+b <- ChromoteSession$new()
+
+# Create a ChromoteSession with a specific height,width
+b <- ChromoteSession$new(height = 1080, width = 1920)
+
+# Navigate to page
+b$Page$navigate("http://www.r-project.org/")
+
+# View current chromote session
+if (interactive()) b$view()
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$new(
   parent = default_chromote_object(),
@@ -268,24 +104,6 @@ enabling/disabling.}
 \subsection{Returns}{
 A new \code{ChromoteSession} object.
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Create a ChromoteSession with a specific height,width
-b <- ChromoteSession$new(height = 1080, width = 1920)
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# View current chromote session
-if (interactive()) b$view()}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-view"></a>}}
@@ -296,23 +114,20 @@ Display the current session in the \code{\link{Chromote}} browser.
 If a \code{\link{Chrome}} browser is being used, this method will open a new tab
 using your \code{\link{Chrome}} browser. When not using a \code{\link{Chrome}} browser, set
 \code{options(browser=)} to change the default behavior of \code{\link[=browseURL]{browseURL()}}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$view()}\if{html}{\out{</div>}}
-}
-
 \subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{# Create a new `ChromoteSession` object.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Create a new `ChromoteSession` object.
 b <- ChromoteSession$new()
 
 # Navigate to page
 b$Page$navigate("http://www.r-project.org/")
 
 # View current chromote session
-if (interactive()) b$view()}
+if (interactive()) b$view()
+}\if{html}{\out{</div>}}
 }
-\if{html}{\out{</div>}}
-
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$view()}\if{html}{\out{</div>}}
 }
 
 }
@@ -321,6 +136,18 @@ if (interactive()) b$view()}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-close}{}}}
 \subsection{Method \code{close()}}{
 Close the Chromote session.
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Create a new `ChromoteSession` object.
+b <- ChromoteSession$new()
+
+# Navigate to page
+b$Page$navigate("http://www.r-project.org/")
+
+# Close current chromote session
+b$close()
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$close(wait_ = TRUE)}\if{html}{\out{</div>}}
 }
@@ -334,27 +161,84 @@ when the \code{ChromoteSession} is closed. Otherwise, block until the
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Close current chromote session
-b$close()}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-screenshot"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-screenshot}{}}}
 \subsection{Method \code{screenshot()}}{
 Take a PNG screenshot
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Create a new `ChromoteSession` object.
+b <- ChromoteSession$new()
+
+# Navigate to page
+b$Page$navigate("http://www.r-project.org/")
+
+# Take screenshot
+tmppngfile <- tempfile(fileext = ".png")
+is_interactive <- interactive() # Display screenshot if interactive
+b$screenshot(tmppngfile, show = is_interactive)
+
+# Show screenshot file info
+unlist(file.info(tmppngfile))
+
+
+# Take screenshot using a selector
+sidebar_file <- tempfile(fileext = ".png")
+b$screenshot(sidebar_file, selector = ".sidebar", show = is_interactive)
+
+# ----------------------------
+# Take screenshots in parallel
+
+urls <- c(
+  "https://www.r-project.org/",
+  "https://github.com/",
+  "https://news.ycombinator.com/"
+)
+# Helper method that:
+# 1. Navigates to the given URL
+# 2. Waits for the page loaded event to fire
+# 3. Takes a screenshot
+# 4. Prints a message
+# 5. Close the ChromoteSession
+screenshot_p <- function(url, filename = NULL) \{
+  if (is.null(filename)) \{
+    filename <- gsub("^.*://", "", url)
+    filename <- gsub("/", "_", filename)
+    filename <- gsub("\\\\.", "_", filename)
+    filename <- sub("_$", "", filename)
+    filename <- paste0(filename, ".png")
+  \}
+
+  b2 <- b$new_session()
+  b2$Page$navigate(url, wait_ = FALSE)
+  b2$Page$loadEventFired(wait_ = FALSE)$
+    then(function(value) \{
+      b2$screenshot(filename, wait_ = FALSE)
+    \})$
+    then(function(value) \{
+      message(filename)
+    \})$
+    finally(function() \{
+      b2$close()
+    \})
+\}
+
+# Take multiple screenshots simultaneously
+ps <- lapply(urls, screenshot_p)
+pa <- promises::promise_all(.list = ps)$then(function(value) \{
+  message("Done!")
+\})
+
+# Block the console until the screenshots finish (optional)
+b$wait_for(pa)
+#> www_r-project_org.png
+#> github_com.png
+#> news_ycombinator_com.png
+#> Done!
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$screenshot(
   filename = "screenshot.png",
@@ -400,87 +284,28 @@ until the \code{ChromoteSession} has saved the screenshot.}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Take screenshot
-tmppngfile <- tempfile(fileext = ".png")
-is_interactive <- interactive() # Display screenshot if interactive
-b$screenshot(tmppngfile, show = is_interactive)
-
-# Show screenshot file info
-unlist(file.info(tmppngfile))
-
-
-# Take screenshot using a selector
-sidebar_file <- tempfile(fileext = ".png")
-b$screenshot(sidebar_file, selector = ".sidebar", show = is_interactive)
-
-# ----------------------------
-# Take screenshots in parallel
-
-urls <- c(
-  "https://www.r-project.org/",
-  "https://github.com/",
-  "https://news.ycombinator.com/"
-)
-# Helper method that:
-# 1. Navigates to the given URL
-# 2. Waits for the page loaded event to fire
-# 3. Takes a screenshot
-# 4. Prints a message
-# 5. Close the ChromoteSession
-screenshot_p <- function(url, filename = NULL) {
-  if (is.null(filename)) {
-    filename <- gsub("^.*://", "", url)
-    filename <- gsub("/", "_", filename)
-    filename <- gsub("\\\\.", "_", filename)
-    filename <- sub("_$", "", filename)
-    filename <- paste0(filename, ".png")
-  }
-
-  b2 <- b$new_session()
-  b2$Page$navigate(url, wait_ = FALSE)
-  b2$Page$loadEventFired(wait_ = FALSE)$
-    then(function(value) {
-      b2$screenshot(filename, wait_ = FALSE)
-    })$
-    then(function(value) {
-      message(filename)
-    })$
-    finally(function() {
-      b2$close()
-    })
-}
-
-# Take multiple screenshots simultaneously
-ps <- lapply(urls, screenshot_p)
-pa <- promises::promise_all(.list = ps)$then(function(value) {
-  message("Done!")
-})
-
-# Block the console until the screenshots finish (optional)
-b$wait_for(pa)
-#> www_r-project_org.png
-#> github_com.png
-#> news_ycombinator_com.png
-#> Done!}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-screenshot_pdf"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-screenshot_pdf}{}}}
 \subsection{Method \code{screenshot_pdf()}}{
 Take a PDF screenshot
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Create a new `ChromoteSession` object.
+b <- ChromoteSession$new()
+
+# Navigate to page
+b$Page$navigate("http://www.r-project.org/")
+
+# Take screenshot
+tmppdffile <- tempfile(fileext = ".pdf")
+b$screenshot_pdf(tmppdffile)
+
+# Show PDF file info
+unlist(file.info(tmppdffile))
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$screenshot_pdf(
   filename = "screenshot.pdf",
@@ -524,31 +349,24 @@ until the \code{ChromoteSession} has saved the screnshot.}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{# Create a new `ChromoteSession` object.
-b <- ChromoteSession$new()
-
-# Navigate to page
-b$Page$navigate("http://www.r-project.org/")
-
-# Take screenshot
-tmppdffile <- tempfile(fileext = ".pdf")
-b$screenshot_pdf(tmppdffile)
-
-# Show PDF file info
-unlist(file.info(tmppdffile))}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-new_session"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-new_session}{}}}
 \subsection{Method \code{new_session()}}{
 Create a new tab / window
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{b1 <- ChromoteSession$new()
+b1$Page$navigate("http://www.google.com")
+b2 <- b1$new_session()
+b2$Page$navigate("http://www.r-project.org/")
+b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
+#> [1] "https://www.google.com/"
+b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
+#> [1] "https://www.r-project.org/"
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$new_session(
   width = 992,
@@ -575,39 +393,21 @@ until the \code{ChromoteSession} has created a new session.}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{b1 <- ChromoteSession$new()
-b1$Page$navigate("http://www.google.com")
-b2 <- b1$new_session()
-b2$Page$navigate("http://www.r-project.org/")
-b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
-#> [1] "https://www.google.com/"
-b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
-#> [1] "https://www.r-project.org/"}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-get_session_id"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-get_session_id}{}}}
 \subsection{Method \code{get_session_id()}}{
 Retrieve the session id
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
+b$get_session_id()
+#> [1] "05764F1D439F4292497A21C6526575DA"
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_session_id()}\if{html}{\out{</div>}}
-}
-
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{b <- ChromoteSession$new()
-b$get_session_id()
-#> [1] "05764F1D439F4292497A21C6526575DA"}
-}
-\if{html}{\out{</div>}}
-
 }
 
 }
@@ -619,6 +419,18 @@ Wait for a Chromote Session to finish. This method will block the R
 session until the provided promise resolves. The loop from
 \verb{$get_child_loop()} will only advance just far enough for the promise to
 resolve.
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
+
+# Async with promise
+p <- b$Browser$getVersion(wait_ = FALSE)
+p$then(str)
+
+# Async with callback
+b$Browser$getVersion(wait_ = FALSE, callback_ = str)
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$wait_for(p)}\if{html}{\out{</div>}}
 }
@@ -630,27 +442,22 @@ resolve.
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{b <- ChromoteSession$new()
-
-# Async with promise
-p <- b$Browser$getVersion(wait_ = FALSE)
-p$then(str)
-
-# Async with callback
-b$Browser$getVersion(wait_ = FALSE, callback_ = str)}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-debug_log"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-debug_log}{}}}
 \subsection{Method \code{debug_log()}}{
 Send a debug log message to the parent \link{Chromote} object
+\subsection{Examples}{
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
+b$parent$debug_messages(TRUE)
+b$Page$navigate("https://www.r-project.org/")
+#> SEND \{"method":"Page.navigate","params":\{"url":"https://www.r-project.org/"\}| __truncated__\}
+# Turn off debug messages
+b$parent$debug_messages(FALSE)
+}\if{html}{\out{</div>}}
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$debug_log(...)}\if{html}{\out{</div>}}
 }
@@ -662,19 +469,6 @@ Send a debug log message to the parent \link{Chromote} object
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{\dontrun{b <- ChromoteSession$new()
-b$parent$debug_messages(TRUE)
-b$Page$navigate("https://www.r-project.org/")
-#> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
-# Turn off debug messages
-b$parent$debug_messages(FALSE)}
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-get_child_loop"></a>}}


### PR DESCRIPTION
Fixes #112

The `\dontrun{}` examples don't look great on the website or in any of the manuals.

This PR moves them into an "Examples" section with some static R code. Their order in the docs move around slightly, but it's the closest we can get to what we want. In particular, it ensures consistent formatting everywhere docs are presented without causing the examples to be tested on CRAN

### Before

![image](https://github.com/rstudio/chromote/assets/5420529/a959b3bd-a159-4157-aeb7-d41a801fe3d4)

### After

![image](https://github.com/rstudio/chromote/assets/5420529/27333506-58bb-4332-9328-572ce380f6ad)
