### PR TITLE
feat(chrome.timeout): Add an option for choosing timeout duration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fixed #89, #91: `find_chrome()` now checks more possible binary names for Chrome or Chromium on Linux and Mac. (thanks @brianmsm and @rossellhayes, #117)
 
+* Fixed #22: Added a new `chromote.timeout` global option that can be used to set the timeout (in seconds) for establishing connections with the Chrome session. (#120)
+
 
 # chromote 0.1.1
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -182,7 +182,8 @@ launch_chrome_impl <- function(path, args, port) {
   )
 
   connected <- FALSE
-  end <- Sys.time() + 10
+  timeout <- getOption("chromote.timeout", 10)
+  end <- Sys.time() + timeout
   while (!connected && Sys.time() < end) {
     if (!p$is_alive()) {
       stop(
@@ -216,7 +217,7 @@ launch_chrome_impl <- function(path, args, port) {
 
   if (!connected) {
     rlang::abort(
-      "Chrome debugging port not open after 10 seconds.",
+      paste("Chrome debugging port not open after", timeout, "seconds."),
       class = "error_stop_port_search"
     )
   }

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -71,8 +71,12 @@ Chromote <- R6Class(
               promise(function(resolve, reject) {
                 private$ws$onOpen(resolve)
               }),
-              10,
-              timeout_message = "Chromote: timed out waiting for WebSocket connection to browser."
+              timeout = getOption("chromote.timeout", 10),
+              timeout_message = paste0(
+                "Chromote: timed out waiting for WebSocket connection to browser. ",
+                "Use `options(chromote.timeout = ", getOption("chromote.timeout", 10), ")` ",
+                "to increase the timeout."
+              )
             )
           })
 


### PR DESCRIPTION
Fixes #22 

Adds a `chromote.timeout` option to control the timeout duration in the websocket and open port connection logic. These were both previously 10 seconds. For simplicity I opted for a single option which is currently undocumented other than in the NEWS item