### PR TITLE
feat(screenshot): Accept additional arguments that are passed to `Page.captureScreenshot()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     promises (>= 1.1.1),
     R6,
     rlang,
+    utils,
     websocket (>= 1.2.0)
 Suggests:
     showimage,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chromote (development version)
 
+* `ChromoteSession$screenshot()` gains an `options` argument that accepts a list of additional options to be passed to the Chrome Devtools Protocol's [`Page.captureScreenshot` method](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot). (#129)
+
 # chromote 0.1.2
 
 * Fixed #109: An error would occur when a `Chromote` object's `$close()` method was called. (#110)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -300,6 +300,8 @@ ChromoteSession <- R6Class(
     #' @param delay The number of seconds to wait before taking the screenshot
     #' after resizing the page. For complicated pages, this may need to be
     #' increased.
+    #' @param options Additional options passed to
+    #'   [`Page.captureScreenshot`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot).
     #' @param wait_ If `FALSE`, return a [promises::promise()] that will resolve
     #' when the `ChromoteSession` has saved the screenshot. Otherwise, block
     #' until the `ChromoteSession` has saved the screenshot.
@@ -312,6 +314,7 @@ ChromoteSession <- R6Class(
       scale = 1,
       show = FALSE,
       delay = 0.5,
+      options = list(),
       wait_ = TRUE
     ) {
       chromote_session_screenshot(
@@ -324,6 +327,7 @@ ChromoteSession <- R6Class(
         scale = scale,
         show = show,
         delay = delay,
+        options = options,
         wait_ = wait_
       )
     },

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -8,6 +8,7 @@ chromote_session_screenshot <- function(
   scale = 1,
   show = FALSE,
   delay = 0.5,
+  options = list(),
   wait_ = TRUE
 ) {
   force(filename)
@@ -39,6 +40,17 @@ chromote_session_screenshot <- function(
     expand <- rep(expand, 4)
   }
 
+  stopifnot(
+    "`options` must be a list" = rlang::is_list(options),
+    "`options` must be named" = rlang::is_named2(options())
+  )
+  screenshot_args <- list(
+    fromSurface = TRUE,
+    captureBeyondViewport = TRUE
+  )
+  for (arg_name in names(options)) {
+    screenshot_args[[arg_name]] <- options[[arg_name]]
+  }
 
   # These vars are used to store information gathered from one step to use
   # in a later step.
@@ -91,18 +103,16 @@ chromote_session_screenshot <- function(
         ymin <- max(ymin, 0)
         ymax <- min(ymax, overall_height)
 
-        self$Page$captureScreenshot(
-          clip = list(
-            x = xmin,
-            y = ymin,
-            width  = xmax - xmin,
-            height = ymax - ymin,
-            scale = scale / private$pixel_ratio
-          ),
-          fromSurface = TRUE,
-          captureBeyondViewport = TRUE,
-          wait_ = FALSE
+        screenshot_args$clip <- list(
+          x = xmin,
+          y = ymin,
+          width  = xmax - xmin,
+          height = ymax - ymin,
+          scale = scale / private$pixel_ratio
         )
+        screenshot_args$wait_ <- FALSE
+
+        do.call(self$Page$captureScreenshot, screenshot_args)
       })$
       then(function(value) {
         image_data <<- value
@@ -112,18 +122,16 @@ chromote_session_screenshot <- function(
     # If cliprect was provided, use it instead of selector
     p <- p$
       then(function(value) {
-        self$Page$captureScreenshot(
-          clip = list(
-            x = cliprect[[1]],
-            y = cliprect[[2]],
-            width  = cliprect[[3]],
-            height = cliprect[[4]],
-            scale = scale / private$pixel_ratio
-          ),
-          fromSurface = TRUE,
-          captureBeyondViewport = TRUE,
-          wait_ = FALSE
+        screenshot_args$clip <- list(
+          x = cliprect[[1]],
+          y = cliprect[[2]],
+          width  = cliprect[[3]],
+          height = cliprect[[4]],
+          scale = scale / private$pixel_ratio
         )
+        screenshot_args$wait_ <- FALSE
+
+        do.call(self$Page$captureScreenshot, screenshot_args)
       })$
       then(function(value) {
         image_data <<- value

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -42,7 +42,7 @@ chromote_session_screenshot <- function(
 
   stopifnot(
     "`options` must be a list" = rlang::is_list(options),
-    "`options` must be named" = rlang::is_named2(options())
+    "`options` must be named" = rlang::is_named2(options)
   )
   # Set up arg list from defaults & user options to pass to `Page$captureScreenshot`
   screenshot_args <- list(

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -45,13 +45,11 @@ chromote_session_screenshot <- function(
     "`options` must be named" = rlang::is_named2(options)
   )
   # Set up arg list from defaults & user options to pass to `Page$captureScreenshot`
-  screenshot_args <- list(
+  screenshot_arg_defaults <- list(
     fromSurface = TRUE,
     captureBeyondViewport = TRUE
   )
-  for (arg_name in names(options)) {
-    screenshot_args[[arg_name]] <- options[[arg_name]]
-  }
+  screenshot_args <- utils::modifyList(screenshot_arg_defaults, options)
 
   # These vars are used to store information gathered from one step to use
   # in a later step.

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -44,6 +44,7 @@ chromote_session_screenshot <- function(
     "`options` must be a list" = rlang::is_list(options),
     "`options` must be named" = rlang::is_named2(options())
   )
+  # Set up arg list from defaults & user options to pass to `Page$captureScreenshot`
   screenshot_args <- list(
     fromSurface = TRUE,
     captureBeyondViewport = TRUE

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -249,6 +249,7 @@ b$wait_for(pa)
   scale = 1,
   show = FALSE,
   delay = 0.5,
+  options = list(),
   wait_ = TRUE
 )}\if{html}{\out{</div>}}
 }
@@ -277,6 +278,9 @@ value or a numeric vector of top, right, bottom, left values.}
 \item{\code{delay}}{The number of seconds to wait before taking the screenshot
 after resizing the page. For complicated pages, this may need to be
 increased.}
+
+\item{\code{options}}{Additional options passed to
+\href{https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot}{\code{Page.captureScreenshot}}.}
 
 \item{\code{wait_}}{If \code{FALSE}, return a \code{\link[promises:promise]{promises::promise()}} that will resolve
 when the \code{ChromoteSession} has saved the screenshot. Otherwise, block


### PR DESCRIPTION
For #96

This PR opens the door for users to set `captureBeyondViewport = FALSE` or the other [available `Page.captureScreenshot` options](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot).

I think in the long run we might want to apply the puppeteer approach, either in chromote or in the `get_screenshot()` method in shinytest2. This moves us in that direction while also unblocking our current testing needs.

## Example

Here's an example that could benefit from the new `options` argument. Note that we currently don't adjust the `format` so screenshots are always in `png` format (I'll do a separate PR to address that problem.)

``` r
library(chromote)
chrm <- ChromoteSession$new()

{
  chrm$Page$navigate("https://posit.co")
  chrm$Page$loadEventFired()
}
#> $timestamp
#> [1] 148446.3

chrm$screenshot(
  "posit.png",
  options = list(
    format = "png",
    captureBeyondViewport = FALSE
  )
)
#> [1] "posit.png"

chrm$screenshot(
  "posit.jpg",
  options = list(
    format = "jpeg",
    captureBeyondViewport = FALSE
  )
)
#> [1] "posit.jpg"

fs::dir_ls(glob = "posit*") |>
  fs::file_info()
#> # A tibble: 2 × 18
#>   path       type     size permissions modification_time   user  group device_id
#>   <fs::path> <fct> <fs::b> <fs::perms> <dttm>              <chr> <chr>     <dbl>
#> 1 posit.jpg  file     141K rw-r--r--   2023-10-26 13:31:57 garr… staff  16777233
#> 2 posit.png  file     485K rw-r--r--   2023-10-26 13:31:56 garr… staff  16777233
#> # ℹ 10 more variables: hard_links <dbl>, special_device_id <dbl>, inode <dbl>,
#> #   block_size <dbl>, blocks <dbl>, flags <int>, generation <dbl>,
#> #   access_time <dttm>, change_time <dttm>, birth_time <dttm>
```