### PR TITLE
feat(screenshot): Infer file format from `filename` extension

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `ChromoteSession$screenshot()` gains an `options` argument that accepts a list of additional options to be passed to the Chrome Devtools Protocol's [`Page.captureScreenshot` method](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot). (#129)
 
+* `ChromoteSession$screenshot()` will now infer the image format from the `filename` extension. Alternatively, you can specify the `format` in the list passed to `options`. (#130)
+
 # chromote 0.1.2
 
 * Fixed #109: An error would occur when a `Chromote` object's `$close()` method was called. (#110)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -286,7 +286,12 @@ ChromoteSession <- R6Class(
     #' #> Done!
     #' ```
     #'
-    #' @param filename File path of where to save the screenshot.
+    #' @param filename File path of where to save the screenshot. The format of
+    #'   the screenshot is inferred from the file extension; use
+    #'   `options = list(format = "jpeg")` to manually choose the format. See
+    #'   [`Page.captureScreenshot`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot)
+    #'   for supported formats; at the time of this release the format options
+    #'   were `"png"` (default), `"jpeg"`, or `"webp"`.
     #' @param selector CSS selector to use for the screenshot.
     #' @param cliprect A list containing `x`, `y`, `width`, and `height`. See
     #' [`Page.Viewport`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-Viewport)

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -177,6 +177,7 @@ chromote_session_screenshot <- function(
 
 screenshot_format <- function(filename) {
   ext <- strsplit(filename, ".", fixed = TRUE)[[1]]
+  if (length(ext) < 2) ext <- "no_ext"
   ext <- ext[length(ext)]
 
   switch(
@@ -188,8 +189,11 @@ screenshot_format <- function(filename) {
     pdf = rlang::abort(
       "Use the `screenshot_pdf()` method to capture a PDF screenshot."
     ),
+    no_ext = rlang::abort(
+      sprintf('Could not guess screenshot format from filename "%s". Does the name include a file extension?', filename)
+    ),
     rlang::abort(
-      sprintf('"%s" is not a supported screenshot format', ext)
+      sprintf('"%s" is not a supported screenshot format.', ext)
     )
   )
 }

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -50,6 +50,9 @@ chromote_session_screenshot <- function(
     captureBeyondViewport = TRUE
   )
   screenshot_args <- utils::modifyList(screenshot_arg_defaults, options)
+  if (is.null(screenshot_args$format)) {
+    screenshot_args$format <- screenshot_format(filename)
+  }
 
   # These vars are used to store information gathered from one step to use
   # in a later step.
@@ -172,6 +175,24 @@ chromote_session_screenshot <- function(
   }
 }
 
+screenshot_format <- function(filename) {
+  ext <- strsplit(filename, ".", fixed = TRUE)[[1]]
+  ext <- ext[length(ext)]
+
+  switch(
+    tolower(ext),
+    png = "png",
+    jpg = ,
+    jpeg = "jpeg",
+    webp = "webp",
+    pdf = rlang::abort(
+      "Use the `screenshot_pdf()` method to capture a PDF screenshot."
+    ),
+    rlang::abort(
+      sprintf('"%s" is not a supported screenshot format', ext)
+    )
+  )
+}
 
 
 chromote_session_screenshot_pdf <- function(

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -257,7 +257,12 @@ b$wait_for(pa)
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{filename}}{File path of where to save the screenshot.}
+\item{\code{filename}}{File path of where to save the screenshot. The format of
+the screenshot is inferred from the file extension; use
+\code{options = list(format = "jpeg")} to manually choose the format. See
+\href{https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot}{\code{Page.captureScreenshot}}
+for supported formats; at the time of this release the format options
+were \code{"png"} (default), \code{"jpeg"}, or \code{"webp"}.}
 
 \item{\code{selector}}{CSS selector to use for the screenshot.}
 


### PR DESCRIPTION
Follow up from #129 (will change base branch and rebase before merging).

This PR infers the screenshot format from the file extension, unless the user has explicitly set `options = list(format = "____")`.

This fixes an un-reported bug in `webshot2` where additional file types are supported by `webshot2::webshot()` but the actual file format is always `.png` even if `.jpg` was requested.

The format detection will throw an error for unknown file types; as mentioned above this can be circumvented by manully providing `format` in the `options` list.

## Reprex

``` r
pkgload::load_all("~/work/rstudio/chromote")
#> ℹ Loading chromote

chrm <- ChromoteSession$new()

{
  chrm$Page$navigate("https://posit.co")
  chrm$Page$loadEventFired()
}
#> $timestamp
#> [1] 149692.2

chrm$screenshot("posit.jpg")
#> [1] "posit.jpg"
chrm$screenshot("posit.jpeg")
#> [1] "posit.jpeg"
chrm$screenshot("posit.webp")
#> [1] "posit.webp"
chrm$screenshot("posit.bad")
#> Error in `screenshot_format()` at chromote/R/screenshot.R:55:4:
#> ! "bad" is not a supported screenshot format
#> Backtrace:
#>     ▆
#>  1. └─chrm$screenshot("posit.bad")
#>  2.   └─chromote:::chromote_session_screenshot(...) at chromote/R/chromote_session.R:320:6
#>  3.     └─chromote:::screenshot_format(filename) at chromote/R/screenshot.R:55:4
#>  4.       └─rlang::abort(...) at chromote/R/screenshot.R:183:2
chrm$screenshot("posit.png")
#> [1] "posit.png"
chrm$screenshot("posit.bad", options = list(format = "png"))
#> [1] "posit.bad"

fs::dir_ls(glob = "posit*") |>
  fs::file_info()
#> # A tibble: 5 × 18
#>   path       type     size permissions modification_time   user  group device_id
#>   <fs::path> <fct> <fs::b> <fs::perms> <dttm>              <chr> <chr>     <dbl>
#> 1 posit.bad  file     884K rw-r--r--   2023-10-26 13:52:45 garr… staff  16777233
#> 2 posit.jpeg file     395K rw-r--r--   2023-10-26 13:52:42 garr… staff  16777233
#> 3 posit.jpg  file     399K rw-r--r--   2023-10-26 13:52:42 garr… staff  16777233
#> 4 posit.png  file     884K rw-r--r--   2023-10-26 13:52:44 garr… staff  16777233
#> 5 posit.webp file     212K rw-r--r--   2023-10-26 13:52:43 garr… staff  16777233
#> # ℹ 10 more variables: hard_links <dbl>, special_device_id <dbl>, inode <dbl>,
#> #   block_size <dbl>, blocks <dbl>, flags <int>, generation <dbl>,
#> #   access_time <dttm>, change_time <dttm>, birth_time <dttm>
```