### PR TITLE
Record the target id in a session

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 SystemRequirements: Google Chrome or other Chromium-based browser.
     chromium: chromium (rpm) or chromium-browser (deb)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # chromote (development version)
 
+* `ChromoteSession` now records the `targetId`. This eliminates one round-trip 
+  to the browser when viewing or closing a session, and will make it possible to
+  re-start a closed session (#94).
+
 * `ChromoteSession$screenshot()` gains an `options` argument that accepts a list of additional options to be passed to the Chrome Devtools Protocol's [`Page.captureScreenshot` method](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot). (#129)
 
 * `ChromoteSession$screenshot()` will now infer the image format from the `filename` extension. Alternatively, you can specify the `format` in the list passed to `options`. (#130)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -1,9 +1,13 @@
-# This represents one _session_ in a Chromote object. Note that in the Chrome
-# DevTools Protocol a session is a debugging interface connected to a
-# _target_; a target is a browser window/tab, or an iframe. A single target
-# can have more than one session connected to it.
-
 #' ChromoteSession class
+#'
+#' @description
+#' This represents one _session_ in a Chromote object. Note that in the Chrome
+#' DevTools Protocol a session is a debugging session connected to a _target_,
+#' a browser window/tab, or an iframe.
+#'
+#' A single target can potentially have more than one session connected to it,
+#' but this is not currently supported by chromote.
+#'
 #' @export
 #' @param timeout_ Number of seconds for \pkg{chromote} to wait for a Chrome
 #' DevTools Protocol response. If `timeout_` is [`rlang::missing_arg()`] and
@@ -76,9 +80,11 @@ ChromoteSession <- R6Class(
           wait_ = FALSE
          )$
           then(function(value) {
+            private$target_id <- value$targetId
             parent$Target$attachToTarget(value$targetId, flatten = TRUE, wait_ = FALSE)
           })
       } else {
+        private$target_id <- targetId
         p <- parent$Target$attachToTarget(targetId, flatten = TRUE, wait_ = FALSE)
       }
 
@@ -157,11 +163,9 @@ ChromoteSession <- R6Class(
     #' if (interactive()) b$view()
     #' ```
     view = function() {
-      tid <- self$Target$getTargetInfo()$targetInfo$targetId
-
       # A data frame of targets, one row per target.
       info <- fromJSON(self$parent$url("/json"))
-      path <- info$devtoolsFrontendUrl[info$id == tid]
+      path <- info$devtoolsFrontendUrl[info$id == private$target_id]
       if (length(path) == 0) {
         stop("Target info not found.")
       }
@@ -188,15 +192,12 @@ ChromoteSession <- R6Class(
     #' when the `ChromoteSession` is closed. Otherwise, block until the
     #' `ChromoteSession` has closed.
     close = function(wait_ = TRUE) {
-      p <- self$Target$getTargetInfo(wait_ = FALSE)
-      p <- p$then(function(target) {
-        tid <- target$targetInfo$targetId
-        # Even if this session calls Target.closeTarget, the response from
-        # the browser is sent without a sessionId. In order to wait for the
-        # correct browser response, we need to invoke this from the parent's
-        # browser-level methods.
-        self$parent$protocol$Target$closeTarget(tid, wait_ = FALSE)
-      })
+      # Even if this session calls Target.closeTarget, the response from
+      # the browser is sent without a sessionId. In order to wait for the
+      # correct browser response, we need to invoke this from the parent's
+      # browser-level methods.
+      p <- self$parent$protocol$Target$closeTarget(private$target_id, wait_ = FALSE)
+
       p <- p$then(function(value) {
         if (isTRUE(value$success)) {
           self$mark_closed()
@@ -421,16 +422,14 @@ ChromoteSession <- R6Class(
 
     #' @description
     #' Retrieve the session id
-    #'
-    #' ## Examples
-    #'
-    #' ```r
-    #' b <- ChromoteSession$new()
-    #' b$get_session_id()
-    #' #> [1] "05764F1D439F4292497A21C6526575DA"
-    #' ```
     get_session_id = function() {
       private$session_id
+    },
+
+    #' @description
+    #' Retrieve the target id
+    get_target_id = function() {
+      private$target_id
     },
 
     #' @description
@@ -555,6 +554,7 @@ ChromoteSession <- R6Class(
 
   private = list(
     session_id = NULL,
+    target_id = NULL,
     is_active_ = NULL,
     event_manager = NULL,
     pixel_ratio = NULL,

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -4,9 +4,12 @@
 \alias{ChromoteSession}
 \title{ChromoteSession class}
 \description{
-ChromoteSession class
+This represents one \emph{session} in a Chromote object. Note that in the Chrome
+DevTools Protocol a session is a debugging session connected to a \emph{target},
+a browser window/tab, or an iframe.
 
-ChromoteSession class
+A single target can potentially have more than one session connected to it,
+but this is not currently supported by chromote.
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
@@ -30,6 +33,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-screenshot_pdf}{\code{ChromoteSession$screenshot_pdf()}}
 \item \href{#method-ChromoteSession-new_session}{\code{ChromoteSession$new_session()}}
 \item \href{#method-ChromoteSession-get_session_id}{\code{ChromoteSession$get_session_id()}}
+\item \href{#method-ChromoteSession-get_target_id}{\code{ChromoteSession$get_target_id()}}
 \item \href{#method-ChromoteSession-wait_for}{\code{ChromoteSession$wait_for()}}
 \item \href{#method-ChromoteSession-debug_log}{\code{ChromoteSession$debug_log()}}
 \item \href{#method-ChromoteSession-get_child_loop}{\code{ChromoteSession$get_child_loop()}}
@@ -408,15 +412,18 @@ until the \code{ChromoteSession} has created a new session.}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-get_session_id}{}}}
 \subsection{Method \code{get_session_id()}}{
 Retrieve the session id
-\subsection{Examples}{
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
-b$get_session_id()
-#> [1] "05764F1D439F4292497A21C6526575DA"
-}\if{html}{\out{</div>}}
-}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_session_id()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-get_target_id"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-get_target_id}{}}}
+\subsection{Method \code{get_target_id()}}{
+Retrieve the target id
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_target_id()}\if{html}{\out{</div>}}
 }
 
 }


### PR DESCRIPTION
Includes some minor documentation improvements.

Part of #94

I tested this by running:

```R
library(chromote)

sess1 <- ChromoteSession$new()
sess1$get_target_id()
sess1$view()

sess2 <- ChromoteSession$new(targetId = sess1$get_target_id())
sess2$view()
sess2$close()

sess1$view()
#> Error: Target info not found
```