### PR TITLE
Check that a chromote connection is alive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 SystemRequirements: Google Chrome or other Chromium-based browser.
     chromium: chromium (rpm) or chromium-browser (deb)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 SystemRequirements: Google Chrome or other Chromium-based browser.
     chromium: chromium (rpm) or chromium-browser (deb)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # chromote (development version)
 
+* `Chromote` gains a new `is_alive()` method equivalent to the old `is_active()` method; i.e. it reports on if there is an active chrome process running in the background.
+
+* Breaking change: `Chromote$is_active()` method now reports if there is an active connection to the underlying chrome instance, rather than whether or not that instance is alive (#94).
+
 * `--disable-gpu` is no longer included in the default Chrome arguments.
 
 * `ChromoteSession` now records the `targetId`. This eliminates one round-trip to the browser when viewing or closing a session. You can now call the `$respawn()` method if a session terminates and you want to reconnect to the same target (#94).

--- a/R/browser.R
+++ b/R/browser.R
@@ -23,6 +23,9 @@ Browser <- R6Class("Browser",
     #' @description Browser process
     get_process = function() private$process,
 
+    #' @description Is the process alive?
+    is_alive = function() private$process$is_alive(),
+
     #' @description Browser Host
     get_host = function() private$host,
 

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -362,8 +362,11 @@ Chromote <- R6Class(
 
     #' @description Close the [`Browser`] object
     close = function() {
+      # Must be alive to be active so we cache value before closing process
+      is_active <- self$is_active()
+
       if (self$is_alive()) {
-        if (self$is_active()) {
+        if (is_active) {
           # send a message to the browser requesting that it close
           self$Browser$close()
         } else {
@@ -372,7 +375,7 @@ Chromote <- R6Class(
         }
       }
 
-      if (self$is_active()) {
+      if (is_active) {
         private$ws$close()
       }
 

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -349,7 +349,7 @@ Chromote <- R6Class(
 
       # Mark all sessions as closed
       for (session in private$sessions) {
-        session$mark_closed()
+        session$mark_closed(FALSE)
       }
       private$sessions <- list()
       invisible(self)
@@ -449,7 +449,7 @@ Chromote <- R6Class(
           return()
 
         private$sessions[[sid]] <- NULL
-        session$mark_closed()
+        session$mark_closed(TRUE)
       })
     },
 

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -363,11 +363,18 @@ Chromote <- R6Class(
 
     #' @description Close the [`Browser`] object
     close = function() {
+      if (self$is_alive()) {
+        if (self$is_active()) {
+          # send a message to the browser requesting that it close
+          self$Browser$close()
+        } else {
+          # terminate the process
+          private$browser$close()
+        }
+      }
+
       if (self$is_active()) {
         private$ws$close()
-      }
-      if (self$is_alive()) {
-        self$Browser$close()
       }
 
       invisible()

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -53,7 +53,6 @@ Chromote <- R6Class(
       list2env(self$protocol, self)
 
       private$event_manager <- EventManager$new(self)
-      private$is_active_ <- TRUE
 
       self$wait_for(p)
 
@@ -384,7 +383,6 @@ Chromote <- R6Class(
   private = list(
     browser = NULL,
     ws = NULL,
-    is_active_ = NULL,
 
     # =========================================================================
     # Browser commands

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -544,7 +544,7 @@ ChromoteSession <- R6Class(
     #'   active debugging session?
     mark_closed = function(target_closed) {
       private$session_is_active <- FALSE
-      private$target_is_active <- FALSE
+      private$target_is_active <- target_closed
     },
 
     #' @description Retrieve active status

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -555,7 +555,10 @@ ChromoteSession <- R6Class(
     #' @description Check that a session is active, erroring if not.
     check_active = function() {
       if (!self$is_active()) {
-        stop("Session ", private$session_id, " has been closed.")
+        abort(c(
+          paste("Session ", private$session_id, " has been closed."),
+          i = "Call session$respawn() to create a new session that connects to the same target."
+        ))
       }
     },
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -540,6 +540,8 @@ ChromoteSession <- R6Class(
 
     #' @description Mark a session, and optionally, the underlying target,
     #'   as closed. For internal use only.
+    #' @param target_closed Has the underlying target been closed as well as the
+    #'   active debugging session?
     mark_closed = function(target_closed) {
       private$session_is_active <- FALSE
       private$target_is_active <- FALSE

--- a/man/Browser.Rd
+++ b/man/Browser.Rd
@@ -18,6 +18,7 @@ should also set private$process.
 \itemize{
 \item \href{#method-Browser-is_local}{\code{Browser$is_local()}}
 \item \href{#method-Browser-get_process}{\code{Browser$get_process()}}
+\item \href{#method-Browser-is_alive}{\code{Browser$is_alive()}}
 \item \href{#method-Browser-get_host}{\code{Browser$get_host()}}
 \item \href{#method-Browser-get_port}{\code{Browser$get_port()}}
 \item \href{#method-Browser-close}{\code{Browser$close()}}
@@ -42,6 +43,16 @@ Returns TRUE if the browser is running locally, FALSE if it's remote.
 Browser process
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Browser$get_process()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Browser-is_alive"></a>}}
+\if{latex}{\out{\hypertarget{method-Browser-is_alive}{}}}
+\subsection{Method \code{is_alive()}}{
+Is the process alive?
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Browser$is_alive()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/Chrome.Rd
+++ b/man/Chrome.Rd
@@ -23,12 +23,13 @@ the browser's system process.
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="close"><a href='../../chromote/html/Browser.html#method-Browser-close'><code>chromote::Browser$close()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_host"><a href='../../chromote/html/Browser.html#method-Browser-get_host'><code>chromote::Browser$get_host()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_port"><a href='../../chromote/html/Browser.html#method-Browser-get_port'><code>chromote::Browser$get_port()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_process"><a href='../../chromote/html/Browser.html#method-Browser-get_process'><code>chromote::Browser$get_process()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_alive"><a href='../../chromote/html/Browser.html#method-Browser-is_alive'><code>chromote::Browser$is_alive()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_local"><a href='../../chromote/html/Browser.html#method-Browser-is_local'><code>chromote::Browser$is_local()</code></a></span></li>
 </ul>
 </details>

--- a/man/ChromeRemote.Rd
+++ b/man/ChromeRemote.Rd
@@ -17,12 +17,13 @@ Remote Chrome process
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="close"><a href='../../chromote/html/Browser.html#method-Browser-close'><code>chromote::Browser$close()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_host"><a href='../../chromote/html/Browser.html#method-Browser-get_host'><code>chromote::Browser$get_host()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_port"><a href='../../chromote/html/Browser.html#method-Browser-get_port'><code>chromote::Browser$get_port()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_process"><a href='../../chromote/html/Browser.html#method-Browser-get_process'><code>chromote::Browser$get_process()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_alive"><a href='../../chromote/html/Browser.html#method-Browser-is_alive'><code>chromote::Browser$is_alive()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_local"><a href='../../chromote/html/Browser.html#method-Browser-is_local'><code>chromote::Browser$is_local()</code></a></span></li>
 </ul>
 </details>

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -57,6 +57,8 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-Chromote-debug_log}{\code{Chromote$debug_log()}}
 \item \href{#method-Chromote-url}{\code{Chromote$url()}}
 \item \href{#method-Chromote-is_active}{\code{Chromote$is_active()}}
+\item \href{#method-Chromote-is_alive}{\code{Chromote$is_alive()}}
+\item \href{#method-Chromote-check_alive}{\code{Chromote$check_alive()}}
 \item \href{#method-Chromote-get_browser}{\code{Chromote$get_browser()}}
 \item \href{#method-Chromote-close}{\code{Chromote$close()}}
 }
@@ -328,6 +330,27 @@ Once initialized, the value returned is \code{TRUE}. If \verb{$close()} has been
 called, this value will be \code{FALSE}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_active()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chromote-is_alive"></a>}}
+\if{latex}{\out{\hypertarget{method-Chromote-is_alive}{}}}
+\subsection{Method \code{is_alive()}}{
+Is connection alive? (i.e. is the websocket open?)
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$is_alive()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chromote-check_alive"></a>}}
+\if{latex}{\out{\hypertarget{method-Chromote-check_alive}{}}}
+\subsection{Method \code{check_alive()}}{
+Check that a chromote instance is active and alive,
+erroring if not.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$check_alive()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -53,7 +53,6 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-Chromote-is_active}{\code{Chromote$is_active()}}
 \item \href{#method-Chromote-is_alive}{\code{Chromote$is_alive()}}
 \item \href{#method-Chromote-check_active}{\code{Chromote$check_active()}}
-\item \href{#method-Chromote-reactivate}{\code{Chromote$reactivate()}}
 \item \href{#method-Chromote-get_browser}{\code{Chromote$get_browser()}}
 \item \href{#method-Chromote-close}{\code{Chromote$close()}}
 }
@@ -342,7 +341,7 @@ Create url for a given path
 \if{html}{\out{<a id="method-Chromote-is_active"></a>}}
 \if{latex}{\out{\hypertarget{method-Chromote-is_active}{}}}
 \subsection{Method \code{is_active()}}{
-Is connection active? (i.e. is the websocket open?)
+Is there an active websocket connection to the browser process?
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_active()}\if{html}{\out{</div>}}
 }
@@ -352,7 +351,7 @@ Is connection active? (i.e. is the websocket open?)
 \if{html}{\out{<a id="method-Chromote-is_alive"></a>}}
 \if{latex}{\out{\hypertarget{method-Chromote-is_alive}{}}}
 \subsection{Method \code{is_alive()}}{
-Is the underlying browser process alive?
+Is the underlying browser process running?
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_alive()}\if{html}{\out{</div>}}
 }
@@ -362,19 +361,11 @@ Is the underlying browser process alive?
 \if{html}{\out{<a id="method-Chromote-check_active"></a>}}
 \if{latex}{\out{\hypertarget{method-Chromote-check_active}{}}}
 \subsection{Method \code{check_active()}}{
-Check that a chromote instance is active and alive,
-erroring if not.
+Check that a chromote instance is active and alive.
+Will automatically reconnect if browser process is alive, but
+there's no active web socket connection.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$check_active()}\if{html}{\out{</div>}}
-}
-
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Chromote-reactivate"></a>}}
-\if{latex}{\out{\hypertarget{method-Chromote-reactivate}{}}}
-\subsection{Method \code{reactivate()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$reactivate()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -52,7 +52,8 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-Chromote-url}{\code{Chromote$url()}}
 \item \href{#method-Chromote-is_active}{\code{Chromote$is_active()}}
 \item \href{#method-Chromote-is_alive}{\code{Chromote$is_alive()}}
-\item \href{#method-Chromote-check_alive}{\code{Chromote$check_alive()}}
+\item \href{#method-Chromote-check_active}{\code{Chromote$check_active()}}
+\item \href{#method-Chromote-reactivate}{\code{Chromote$reactivate()}}
 \item \href{#method-Chromote-get_browser}{\code{Chromote$get_browser()}}
 \item \href{#method-Chromote-close}{\code{Chromote$close()}}
 }
@@ -341,9 +342,7 @@ Create url for a given path
 \if{html}{\out{<a id="method-Chromote-is_active"></a>}}
 \if{latex}{\out{\hypertarget{method-Chromote-is_active}{}}}
 \subsection{Method \code{is_active()}}{
-Retrieve active status
-Once initialized, the value returned is \code{TRUE}. If \verb{$close()} has been
-called, this value will be \code{FALSE}.
+Is connection active? (i.e. is the websocket open?)
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_active()}\if{html}{\out{</div>}}
 }
@@ -353,20 +352,29 @@ called, this value will be \code{FALSE}.
 \if{html}{\out{<a id="method-Chromote-is_alive"></a>}}
 \if{latex}{\out{\hypertarget{method-Chromote-is_alive}{}}}
 \subsection{Method \code{is_alive()}}{
-Is connection alive? (i.e. is the websocket open?)
+Is the underlying browser process alive?
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$is_alive()}\if{html}{\out{</div>}}
 }
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Chromote-check_alive"></a>}}
-\if{latex}{\out{\hypertarget{method-Chromote-check_alive}{}}}
-\subsection{Method \code{check_alive()}}{
+\if{html}{\out{<a id="method-Chromote-check_active"></a>}}
+\if{latex}{\out{\hypertarget{method-Chromote-check_active}{}}}
+\subsection{Method \code{check_active()}}{
 Check that a chromote instance is active and alive,
 erroring if not.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$check_alive()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$check_active()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chromote-reactivate"></a>}}
+\if{latex}{\out{\hypertarget{method-Chromote-reactivate}{}}}
+\subsection{Method \code{reactivate()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$reactivate()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -576,13 +576,20 @@ For internal use only.
 \if{html}{\out{<a id="method-ChromoteSession-mark_closed"></a>}}
 \if{latex}{\out{\hypertarget{method-ChromoteSession-mark_closed}{}}}
 \subsection{Method \code{mark_closed()}}{
-Disable callbacks for a given session.
-
-For internal use only.
+Mark a session, and optionally, the underlying target,
+as closed. For internal use only.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$mark_closed()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$mark_closed(target_closed)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{target_closed}}{Has the underlying target been closed as well as the
+active debugging session?}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-is_active"></a>}}

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -38,6 +38,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-invoke_event_callbacks}{\code{ChromoteSession$invoke_event_callbacks()}}
 \item \href{#method-ChromoteSession-mark_closed}{\code{ChromoteSession$mark_closed()}}
 \item \href{#method-ChromoteSession-is_active}{\code{ChromoteSession$is_active()}}
+\item \href{#method-ChromoteSession-check_active}{\code{ChromoteSession$check_active()}}
 \item \href{#method-ChromoteSession-init_promise}{\code{ChromoteSession$init_promise()}}
 }
 }
@@ -576,6 +577,16 @@ Once initialized, the value returned is \code{TRUE}. If \verb{$close()} has been
 called, this value will be \code{FALSE}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$is_active()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-check_active"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-check_active}{}}}
+\subsection{Method \code{check_active()}}{
+Check that a session is active, erroring if not.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$check_active()}\if{html}{\out{</div>}}
 }
 
 }


### PR DESCRIPTION
When your computer goes to sleep, the websocket and all debugging sessions are closed. This PR ensures that Chromote and ChromoteSession report this accurately.

I distinguished between active and alive for Chromote but not ChromoteSession since the browser process continues to run in the background, even though we have lost our connection to it. There's no way to restore a closed debugging session. However, I'm not sure about the names; maybe I have alive and active around the wrong way?

Part of #94

---

I tested this code with:

```R
library(chromote)

sess <- ChromoteSession$new()
sess$is_active()
#> [1] TRUE
sess$parent$is_alive()
#> [1] TRUE

# SLEEP

sess$is_active()
#> [1] FALSE
sess$parent$is_alive()
#> [1] FALSE
```