### PR TITLE
Drop the --disable-gpu flag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chromote (development version)
 
+* `--disable-gpu` is no longer included in the default Chrome arguments.
+
 * `ChromoteSession` now records the `targetId`. This eliminates one round-trip to the browser when viewing or closing a session, and will make it possible to re-start a closed session (#94).
 
 * `ChromoteSession$screenshot()` gains an `options` argument that accepts a list of additional options to be passed to the Chrome Devtools Protocol's [`Page.captureScreenshot` method](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot). (#129)

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -556,8 +556,6 @@ is_missing_linux_user <- cache_value(function() {
 #' Default chromote arguments are composed of the following values (when
 #' appropriate):
 #'
-#' * [`"--disable-gpu"`](https://peter.sh/experiments/chromium-command-line-switches/#disable-gpu)
-#'   * \verb{Disables GPU hardware acceleration. If software renderer is not in place, then the GPU process won't launch.}
 #' * [`"--no-sandbox"`](https://peter.sh/experiments/chromium-command-line-switches/#no-sandbox)
 #'   * Only added when `CI` system environment variable is set, when the
 #'     user on a Linux system is not set, or when executing inside a Docker container.
@@ -584,9 +582,6 @@ is_missing_linux_user <- cache_value(function() {
 #' @export
 default_chrome_args <- function() {
   c(
-    # Better cross platform support
-    "--disable-gpu",
-
     # > Note: --no-sandbox is not needed if you properly setup a user in the container.
     # https://developers.google.com/web/updates/2017/04/headless-chrome
     if (is_inside_ci() || is_missing_linux_user() || is_inside_docker()) {
@@ -638,7 +633,7 @@ reset_chrome_args <- function() {
 #' @examples
 #' old_chrome_args <- get_chrome_args()
 #'
-#' # Only disable the gpu and using `/dev/shm`
+#' # Disable the gpu and use `/dev/shm`
 #' set_chrome_args(c("--disable-gpu", "--disable-dev-shm-usage"))
 #'
 #' #... Make new `Chrome` or `ChromoteSession` instance

--- a/man/default_chrome_args.Rd
+++ b/man/default_chrome_args.Rd
@@ -32,10 +32,6 @@ list of possible arguments.
 Default chromote arguments are composed of the following values (when
 appropriate):
 \itemize{
-\item \href{https://peter.sh/experiments/chromium-command-line-switches/#disable-gpu}{\code{"--disable-gpu"}}
-\itemize{
-\item \verb{Disables GPU hardware acceleration. If software renderer is not in place, then the GPU process won't launch.}
-}
 \item \href{https://peter.sh/experiments/chromium-command-line-switches/#no-sandbox}{\code{"--no-sandbox"}}
 \itemize{
 \item Only added when \code{CI} system environment variable is set, when the
@@ -82,7 +78,7 @@ passed when initializing. Returns the updated defaults.
 \examples{
 old_chrome_args <- get_chrome_args()
 
-# Only disable the gpu and using `/dev/shm`
+# Disable the gpu and use `/dev/shm`
 set_chrome_args(c("--disable-gpu", "--disable-dev-shm-usage"))
 
 #... Make new `Chrome` or `ChromoteSession` instance

--- a/tests/testthat/test-default_chromote_args.R
+++ b/tests/testthat/test-default_chromote_args.R
@@ -1,5 +1,5 @@
 
-min_chrome_arg_length <- if (is_inside_ci()) 5 else 4
+min_chrome_arg_length <- if (is_inside_ci()) 4 else 3
 
 test_that("default args are retrieved", {
   expect_gte(length(default_chrome_args()), min_chrome_arg_length)


### PR DESCRIPTION
It is no longer needed as the underlying bugs have been fixed in chromium (for multiple years). This flag was dropped in puppeteer in https://github.com/puppeteer/puppeteer/pull/2908 and https://github.com/puppeteer/puppeteer/pull/4523.