### PR TITLE
feat: Include path to chrome log file in failed to connect message

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -187,13 +187,24 @@ launch_chrome_impl <- function(path, args, port) {
   end <- Sys.time() + timeout
   while (!connected && Sys.time() < end) {
     if (!p$is_alive()) {
+      error_logs <- paste(readLines(p$get_error_file()), collapse = "\n")
+      stdout_file <- p$get_output_file()
+      
       stop(
-        "Failed to start chrome. Error: ",
-        paste(readLines(p$get_error_file()), collapse = "\n"),
-        "\nMore details may be found in the following log file:\n",
-        p$get_output_file()
+        if (nzchar(error_logs)) {
+          paste0("Failed to start chrome. Error:\n", error_logs)
+        } else {
+          "Failed to start chrome. (No error messages were printed.)"
+        },
+        if (file.info(stdout_file)$size > 0) {
+          paste0(
+            "\nThe following log file may contain more information:\n",
+            stdout_file,
+          )
+        }
       )
     }
+    
     tryCatch(
       {
         # Find port number from output

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -189,7 +189,9 @@ launch_chrome_impl <- function(path, args, port) {
     if (!p$is_alive()) {
       stop(
         "Failed to start chrome. Error: ",
-        paste(readLines(p$get_error_file()), collapse = "\n")
+        paste(readLines(p$get_error_file()), collapse = "\n"),
+        "\nMore details may be found in the following log file:\n",
+        p$get_output_file()
       )
     }
     tryCatch(


### PR DESCRIPTION
When we fail to launch chrome, we print already out the contents of stderr in the error message. But there are often important details hidden in the stdout logs.

This PR adds the full path to the log file with the lines printed to stdout in the error message when chrome fails to launch.

Fixes #151 