### PR TITLE
Allow enable() and disable() methods to be used when auto_events is TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # chromote (development version)
 
+* chromote sessions allow you to call `enable()` methods manually event when
+  `auto_events` is `FALSE`. If an `enable()` method is called, chromote will
+  not call it again automatically, until you manually `disable()` it (#144).
 # chromote 0.2.0
 
 ## Breaking changes

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -626,6 +626,14 @@ ChromoteSession <- R6Class(
     register_event_listener = function(event, callback = NULL, timeout = NULL) {
       self$check_active()
       private$event_manager$register_event_listener(event, callback, timeout)
+    },
+
+    manually_enable = function(domain) {
+      private$event_manager$manually_enable(domain)
+    },
+
+    manually_disable = function(domain) {
+      private$event_manager$manually_disable(domain)
     }
   )
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -1070,13 +1070,9 @@ Currently setting custom headers requires a little extra work because it require
 
 ```R
 b <- ChromoteSession$new()
-# Currently need to manually enable Network domain notifications. Calling
-# b$Network$enable() would do it, but calling it directly will bypass the
-# callback counting and the notifications could get automatically disabled by a
-# different Network event. We'll enable notifications for the Network domain by
-# listening for a particular event. We'll also store a callback that will
-# decrement the callback counter, so that we can disable notifications ater.
-disable_network_notifications <- b$Network$responseReceived(function (msg) NULL)
+# Currently need to manually enable Network domain notifications.
+b$Network$enable()
+
 b$Network$setExtraHTTPHeaders(headers = list(
   foo = "bar",
   header1 = "value1"
@@ -1097,9 +1093,8 @@ b$Page$navigate("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
 
-# Disable extra headers entirely, by decrementing Network callback counter,
-# which will disable Network notifications.
-disable_network_notifications()
+# Disable extra headers entirely, by disabling Network notifications.
+b$Network$disable()
 ```
 
 ### Custom User-Agent


### PR DESCRIPTION
Fixes #144.

Works by keeping track of which domains have been manually enabled, and does not call `enable()` in `inc_event_callback_count()` or `disable()` in `dec_event_callback_count()` until the corresponding `disable()` method is called.

If the event callback number is more than 0, and `disable()` is called, automatic event handling is disabled until the callback count reaches 0 (not by design, just due to how the callback count functions were written in the first place).