### PR TITLE
Allow for usage on OpenBSD

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -127,7 +127,8 @@ find_chrome_linux <- function() {
     "chromium-browser",
     "chromium",
     "google-chrome-beta",
-    "google-chrome-unstable"
+    "google-chrome-unstable",
+    "chrome"
   )
 
   for (path in possible_names) {

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -603,7 +603,7 @@ is_inside_ci <- function() {
 
 
 is_linux <- function() {
-  Sys.info()[["sysname"]] == "Linux"
+  Sys.info()[["sysname"]] %in% c("Linux", "OpenBSD")
 }
 is_missing_linux_user <- cache_value(function() {
   is_linux() &&

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,7 @@ is_windows <- function() .Platform$OS.type == "windows"
 
 is_mac     <- function() Sys.info()[['sysname']] == 'Darwin'
 
-is_linux   <- function() Sys.info()[['sysname']] == 'Linux'
+is_linux   <- function() Sys.info()[['sysname']] %in% c('Linux', 'OpenBSD')
 
 # =============================================================================
 # Vectors


### PR DESCRIPTION
Allows using `chromote` in OpenBSD.
Passed all tests except for `test-chromote-session.R`, which was skipped, saying "chromote not available".