### PR TITLE
Remove redundant function

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -602,9 +602,6 @@ is_inside_ci <- function() {
 }
 
 
-is_linux <- function() {
-  Sys.info()[["sysname"]] == "Linux"
-}
 is_missing_linux_user <- cache_value(function() {
   is_linux() &&
     system("id", ignore.stdout = TRUE) != 0


### PR DESCRIPTION
is_linux() is defined in utils.R, there is no need to re-define it in chromote.R