### PR TITLE
Adds support for chromote under OpenBSD

### DIFF
--- a/R/chrome.R
+++ b/R/chrome.R
@@ -84,14 +84,7 @@ find_chrome <- function() {
     } else if (is_windows()) {
       inform_if_chrome_not_found(find_chrome_windows())
 
-    } else if (is_linux()) {
-      inform_if_chrome_not_found(
-        find_chrome_linux(),
-        searched_for = "`google-chrome`, `chromium-browser` and `chrome` were",
-        extra_advice = "or adding one of these executables to your PATH"
-      )
-
-    } else if (is_openbsd()) {
+    } else if (is_linux() || is_openbsd()) {
       inform_if_chrome_not_found(
         find_chrome_linux(),
         searched_for = "`google-chrome`, `chromium-browser` and `chrome` were",

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -87,7 +87,14 @@ find_chrome <- function() {
     } else if (is_linux()) {
       inform_if_chrome_not_found(
         find_chrome_linux(),
-        searched_for = "`google-chrome` and `chromium-browser` were",
+        searched_for = "`google-chrome`, `chromium-browser` and `chrome` were",
+        extra_advice = "or adding one of these executables to your PATH"
+      )
+
+    } else if (is_openbsd()) {
+      inform_if_chrome_not_found(
+        find_chrome_linux(),
+        searched_for = "`google-chrome`, `chromium-browser` and `chrome` were",
         extra_advice = "or adding one of these executables to your PATH"
       )
 
@@ -127,7 +134,8 @@ find_chrome_linux <- function() {
     "chromium-browser",
     "chromium",
     "google-chrome-beta",
-    "google-chrome-unstable"
+    "google-chrome-unstable",
+    "chrome"
   )
 
   for (path in possible_names) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,6 +12,8 @@ is_mac     <- function() Sys.info()[['sysname']] == 'Darwin'
 
 is_linux   <- function() Sys.info()[['sysname']] == 'Linux'
 
+is_openbsd <- function() Sys.info()[['sysname']] == "OpenBSD"
+
 # =============================================================================
 # Vectors
 # =============================================================================


### PR DESCRIPTION
Two changes are required:
- Checking for the appropriate `sysname`
- Adding `chrome` to the list of searched executables, because that's the name of the main executable file, installed by the OpenBSD package.