### PR TITLE
hot-fix: v0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chromote
 Title: Headless Chrome Web Browser Interface
-Version: 0.3.0.9000
+Version: 0.3.1
 Authors@R: c(
     person("Winston", "Chang", , "winston@posit.co", role = c("aut", "cre")),
     person("Barret", "Schloerke", , "barret@posit.co", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chromote 0.3.1
 
+* Fixed a typo that caused `launch_chrome()` to throw an error. (#175)
+
 # chromote 0.3.0
 
 * The headless mode used by Chrome can now be selected with the `chromote.headless` option or `CHROMOTE_HEADLESS` environment variable. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# chromote (development version)
+# chromote 0.3.1
 
 # chromote 0.3.0
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -162,7 +162,8 @@ inform_if_chrome_not_found <- function(
 
 chrome_headless_mode <- function() {
   opt <- getOption("chromote.headless", NULL)
-  env <- Sys.getenv("CHROMOTE_HEADLESS", NULL)
+  env <- Sys.getenv("CHROMOTE_HEADLESS", "")
+  env <- if (nzchar(env)) env
   
   # TODO Chrome v128 changed the default from --headless=old to --headless=new
   # in 2024-08. Old headless mode was effectively a separate browser render,

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -163,7 +163,7 @@ inform_if_chrome_not_found <- function(
 chrome_headless_mode <- function() {
   opt <- getOption("chromote.headless", NULL)
   env <- Sys.getenv("CHROMOTE_HEADLESS", "")
-  env <- if (nzchar(env)) env
+  env <- if (nzchar(env)) env else NULL
   
   # TODO Chrome v128 changed the default from --headless=old to --headless=new
   # in 2024-08. Old headless mode was effectively a separate browser render,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,6 @@
+We apologize for re-submitting so quickly. We realized we introduced a serious
+bug in the last release and a quick fix is essential.
+
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes


### PR DESCRIPTION
Fixes this :facepalm: :facepalm: :facepalm: of a bug I just introduced.

``` r
Sys.getenv("CHROMOTE_HEADLESS", NULL)
#> Error in Sys.getenv("CHROMOTE_HEADLESS", NULL): wrong type for argument
```

