### PR TITLE
Allow changing of `auto_events` for specific domains.

### DIFF
--- a/R/event_manager.R
+++ b/R/event_manager.R
@@ -122,7 +122,7 @@ EventManager <- R6Class("EventManager",
       # If we're doing auto events and we're going from 0 to 1, enable events
       # for this domain. (Some domains do not require or have an .enable
       # method.)
-      if (private$session$get_auto_events() &&
+      if (domain %in% private$session$get_auto_events() &&
           private$event_callback_counts[[domain]] == 1 &&
           isTRUE(private$event_enable_domains[[domain]]))
       {
@@ -139,7 +139,7 @@ EventManager <- R6Class("EventManager",
       private$session$debug_log("Callbacks for ", domain, "--: ", private$event_callback_counts[[domain]])
       # If we're doing auto events and we're going from 1 to 0, disable
       # enable events for this domain.
-      if (private$session$get_auto_events() &&
+      if (domain %in% private$session$get_auto_events() &&
           private$event_callback_counts[[domain]] == 0 &&
           isTRUE(private$event_enable_domains[[domain]]))
       {

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,6 +76,30 @@ find_domain <- function(event) {
   sub("\\.[^.]+", "", event)
 }
 
+check_auto_events <- function(auto_events, protocol, allow_null = FALSE) {
+  if (allow_null && is.null(auto_events)) {
+    return(NULL)
+  }
+
+  # All the domains that can be enabled
+  accepted_auto_events <- names(Filter(function(domain) {
+    is.function(domain$enable)
+  }, protocol))
+
+  if (is.logical(auto_events)) {
+    # TRUE enables auto_events for all domains, FALSE does the opposite
+    if (auto_events) accepted_auto_events else character()
+  } else {
+    bad_auto_events <- setdiff(auto_events, accepted_auto_events)
+
+    if (length(bad_auto_events) > 0) {
+      stop(paste0("Invalid auto_events: ", paste(bad_auto_events, collapse = ", ")))
+    }
+
+    auto_events
+  }
+}
+
 
 # =============================================================================
 # Browser

--- a/README.Rmd
+++ b/README.Rmd
@@ -1070,13 +1070,11 @@ Currently setting custom headers requires a little extra work because it require
 
 ```R
 b <- ChromoteSession$new()
-# Currently need to manually enable Network domain notifications. Calling
-# b$Network$enable() would do it, but calling it directly will bypass the
-# callback counting and the notifications could get automatically disabled by a
-# different Network event. We'll enable notifications for the Network domain by
-# listening for a particular event. We'll also store a callback that will
-# decrement the callback counter, so that we can disable notifications ater.
-disable_network_notifications <- b$Network$responseReceived(function (msg) NULL)
+# We want to handle Network domain notifications ourselves, so we disable auto events
+# for the Network domain.
+b$disable_auto_events("Network")
+b$Network$enable()
+
 b$Network$setExtraHTTPHeaders(headers = list(
   foo = "bar",
   header1 = "value1"
@@ -1096,10 +1094,11 @@ b$Network$setExtraHTTPHeaders(headers = list(a=1)[0])
 b$Page$navigate("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
-
-# Disable extra headers entirely, by decrementing Network callback counter,
-# which will disable Network notifications.
-disable_network_notifications()
+# Disable network notifications
+b$Network$disable()
+# If we're going to use the Network domain later, it may be useful to enable auto_events
+# for the domain again
+b$enable_auto_events("Network")
 ```
 
 ### Custom User-Agent


### PR DESCRIPTION
Fixes #144 
Alternative to #156 that allows more control.

Allows `auto_events` to be set both dynamically and on a per-domain level in `Chromote` and `ChromoteSession`. Does not change any default behaviour except for `get_auto_events()`, which returns a character vector of domains rather than a boolean.

Examples:
```r
# By default, auto_events depends on the parent Chromote object
session <- ChromoteSession$new()

session$get_auto_events()
#>  [1] "Accessibility"        "Animation"            "Audits"              
#>  [4] "Autofill"             "CSS"                  "Cast"                
#>  [7] "DOM"                  "DOMSnapshot"          "DOMStorage"          
#> [10] "Database"             "HeadlessExperimental" "IndexedDB"           
#> [13] "Inspector"            "LayerTree"            "Log"                 
#> [16] "Network"              "Overlay"              "Page"                
#> [19] "Performance"          "PerformanceTimeline"  "Security"            
#> [22] "ServiceWorker"        "Fetch"                "WebAudio"            
#> [25] "WebAuthn"             "Media"                "DeviceAccess"        
#> [28] "Preload"              "FedCm"                "BluetoothEmulation"  
#> [31] "Console"              "Debugger"             "HeapProfiler"        
#> [34] "Profiler"             "Runtime"

# Disable auto_events for all domains
session$disable_auto_events()

session$get_auto_events()
#> character(0)

# Enable auto_events for just the Network domain
session$enable_auto_events("Network")

session$get_auto_events()
#> [1] "Network"

# Depend on the parent again
session$enable_auto_events(NULL)

session$get_auto_events()
#>  [1] "Accessibility"        "Animation"            "Audits"              
#>  [4] "Autofill"             "CSS"                  "Cast"                
#>  [7] "DOM"                  "DOMSnapshot"          "DOMStorage"          
#> [10] "Database"             "HeadlessExperimental" "IndexedDB"           
#> [13] "Inspector"            "LayerTree"            "Log"                 
#> [16] "Network"              "Overlay"              "Page"                
#> [19] "Performance"          "PerformanceTimeline"  "Security"            
#> [22] "ServiceWorker"        "Fetch"                "WebAudio"            
#> [25] "WebAuthn"             "Media"                "DeviceAccess"        
#> [28] "Preload"              "FedCm"                "BluetoothEmulation"  
#> [31] "Console"              "Debugger"             "HeapProfiler"        
#> [34] "Profiler"             "Runtime"
```