### PR TITLE
fix: Chrome no longer supports old headless mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chromote
 Title: Headless Chrome Web Browser Interface
-Version: 0.3.1
+Version: 0.3.1.9000
 Authors@R: c(
     person("Winston", "Chang", , "winston@posit.co", role = c("aut", "cre")),
     person("Barret", "Schloerke", , "barret@posit.co", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# chromote (development version)
+
+* Chrome v132 and later no longer support [old headless mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome). As such, `chromote` no longer defaults to using `--headless=old` and now uses `--headless` when running Chrome. You can still use the `chromote.headless` option or `CHROMOTE_HEADLESS` environment variable to configure the `--headless` flag if you're using an older version of Chrome. (#187)
+
 # chromote 0.3.1
 
 * Fixed a typo that caused `launch_chrome()` to throw an error. (#175)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -170,20 +170,16 @@ chrome_headless_mode <- function() {
   # and while more performant did not share the same browser implementation as
   # headful Chrome. New headless mode will likely be useful to some, but in most
   # chromote use cases -- printing to PDF and testing -- we are not ready to
-  # move to the new mode. We'll use `--headless=old` as the default for now
-  # until the new mode is more stable, or until we add support for downloading
-  # specific versions of Chrome. (See rstudio/chromote#171)
-  default_mode <- "old"
-  mode <- tolower(opt %||% env %||% default_mode)
+  # move to the new mode. Even once removed, the option may be useful if we
+  # add support downloading specific versions of Chrome. (See rstudio/chromote#171)
+  # 2025-01-16: Chrome v132 removed headless mode (rstudio/chromote#187)
+  mode <- opt %||% env
 
-  if (!mode %in% c("old", "new")) {
-    used <- if (!is.null(opt)) "chromote.headless" else "CHROMOTE_HEADLESS"
-    rlang::inform(
-      sprintf('Invalid value for `%s`. Using `"%s"`.', used, default_mode)
-    )
-    mode <- default_mode
+  if (is.null(mode)) {
+    return("--headless")
   }
 
+  # Just pass headless along directly, Chrome will error if needed
   sprintf("--headless=%s", mode)
 }
 


### PR DESCRIPTION
Fixes #187

We now default to `--headless` and pass whatever value is given in `chromote.headless` or `CHROMOTE_HEADLESS` along directly to Chrome, relying on Chrome to fail for invalid headless values (if it fails at all).



