### PR TITLE
feat: Set a user-specific crash dump directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added `chromote_info()`, a new utility function to print out key information about chromote and Chrome. Useful when debugging chromote or reporting an issue. (#190)
 
+* chromote now uses a consistent prefix for logs, e.g `{tempdir}/chrome-{id}-stdout.log` and `{tempdir}/chrome-{id}-stderr.log`. chromote also now uses `--crash-dumps-dir` to set a session-specific temp directory. (#194)
+
 # chromote 0.3.1
 
 * Fixed a typo that caused `launch_chrome()` to throw an error. (#175)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -390,17 +390,24 @@ launch_chrome <- function(path = find_chrome(), args = get_chrome_args()) {
 }
 
 launch_chrome_impl <- function(path, args, port) {
+  # Create temp folders for logs and crashes, grouped by chromote session
+  tmp_session <- tempfile("chrome-", fileext = "%s")
+  path_dir_crash <- sprintf(tmp_session, "-crashpad")
+  path_stdout <- sprintf(tmp_session, "-stdout.log")
+  path_stderr <- sprintf(tmp_session, "-stderr.log")
+
   p <- process$new(
     command = path,
     args = c(
       chrome_headless_mode(),
       paste0("--remote-debugging-port=", port),
       paste0("--remote-allow-origins=http://127.0.0.1:", port),
+      paste0("--crash-dumps-dir=", path_dir_crash),
       args
     ),
     supervise = TRUE,
-    stdout = tempfile("chrome-stdout-", fileext = ".log"),
-    stderr = tempfile("chrome-stderr-", fileext = ".log"),
+    stdout = path_stdout,
+    stderr = path_stderr,
     echo_cmd = getOption("chromote.launch.echo_cmd", FALSE)
   )
 

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -390,7 +390,7 @@ launch_chrome <- function(path = find_chrome(), args = get_chrome_args()) {
 }
 
 launch_chrome_impl <- function(path, args, port) {
-  # Create temp folders for logs and crashes, grouped by chromote session
+  # Create temp locations for logs and crashes, grouped by chromote session
   tmp_session <- tempfile("chrome-", fileext = "%s")
   path_dir_crash <- sprintf(tmp_session, "-crashpad")
   path_stdout <- sprintf(tmp_session, "-stdout.log")


### PR DESCRIPTION
Fixes #134

Sets `--crash-dumps-dir` for each session and uses `tempfile()` to create a consistent path name for a given session. (Previously, stdout and stderr would be written to log files with different "hashes".)

```r
options(chromote.launch.echo_cmd = TRUE)
b <- ChromoteSession$new()
#> Running '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \
#>   --headless '--remote-debugging-port=23311' \
#>   '--remote-allow-origins=http://127.0.0.1:23311' \
#>   '--crash-dumps-dir=/var/folders/yl/0xhq7c7n3z7_9hp1356kctbr0000gp/T//RtmpcsWZVF/chrome-bd71710535fb-crashpad' \
#>   '--force-color-profile=srgb' --disable-extensions --mute-audio
```

With this change, we now use the same tempdir prefix for all three session-specific files/directories:

* `{tempdir}/chrome-bd71710535fb-crashpad/` for crash dumps
* `{tempdir}/chrome-bd71710535fb-stdout.log`
* `{tempdir}/chrome-bd71710535fb-stderr.log`