### PR TITLE
feat: Disable auto_events for a domain when `$enable()` is called manually

### DIFF
--- a/R/chromote.R
+++ b/R/chromote.R
@@ -619,11 +619,9 @@ cache_value <- function(fn) {
 # This should not change over time. Cache it
 is_inside_docker <- cache_value(function() {
   file.exists("/.dockerenv") ||
-    (
-      is_linux() &&
-        file.exists("/proc/self/cgroup") &&
-        any(grepl("docker", readLines("/proc/self/cgroup"), fixed = TRUE))
-    )
+    (is_linux() &&
+      file.exists("/proc/self/cgroup") &&
+      any(grepl("docker", readLines("/proc/self/cgroup"), fixed = TRUE)))
 })
 
 # This is a _fast_ function. Do not cache it.

--- a/R/event_manager.R
+++ b/R/event_manager.R
@@ -140,7 +140,13 @@ EventManager <- R6Class(
         1,
         private$auto_event_callback_count_threshold[[domain]]
       )
-      if (private$event_callback_counts[[domain]] != threshold) return()
+      if (private$event_callback_counts[[domain]] < threshold) {
+        # The callback event count decremented somehow, update auto event threshold
+        private$auto_event_callback_count_threshold <-
+          private$event_callback_counts[[domain]] + 1
+
+        return()
+      }
 
       # ...then automatically enable events.
       private$session$debug_log("Enabling events for ", domain)

--- a/R/event_manager.R
+++ b/R/event_manager.R
@@ -75,7 +75,7 @@ EventManager <- R6Class(
       private$event_callbacks$remove(event)
     },
 
-    track_domain_event_activation = function(command) {
+    track_domain_manual_event_activation = function(command) {
       if (!private$session$get_auto_events()) return()
 
       # Tracks calls to domain-event enabling commands, like `Fetch.enable` or
@@ -127,7 +127,7 @@ EventManager <- R6Class(
 
     event_domain_manually_enabled = list(),
 
-    maybe_event_domain_enable = function(domain) {
+    maybe_auto_event_domain_enable = function(domain) {
       # If we're doing auto events
       if (!private$session$get_auto_events()) return()
       # and this domain requires events (not all domains require or have an .enable method)
@@ -146,7 +146,7 @@ EventManager <- R6Class(
       private$event_domain_manually_enabled[[domain]] <- FALSE
     },
 
-    maybe_event_domain_disable = function(domain) {
+    maybe_auto_event_domain_disable = function(domain) {
       # If we're doing auto events
       if (!private$session$get_auto_events()) return()
       # and the domain requires events
@@ -212,7 +212,7 @@ EventManager <- R6Class(
         private$event_callback_counts[[domain]]
       )
 
-      private$maybe_event_domain_enable(domain)
+      private$maybe_auto_event_domain_enable(domain)
 
       invisible(private$event_callback_counts[[domain]])
     },
@@ -228,7 +228,7 @@ EventManager <- R6Class(
         private$event_callback_counts[[domain]]
       )
 
-      private$maybe_event_domain_disable(domain)
+      private$maybe_auto_event_domain_disable(domain)
 
       invisible(private$event_callback_counts[[domain]])
     }

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -144,6 +144,9 @@ gen_command_body <- function(method_name, params) {
     # Check for missing non-optional args
     !!!check_missing_exprs
 
+    # Tracks state of `{domain}.enable` and `.disable` commands
+    private$event_manager$track_domain_event_activation(!!method_name)
+
     msg <- list(
       method = !!method_name,
       params = drop_nulls(list(!!!param_list))

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -145,7 +145,7 @@ gen_command_body <- function(method_name, params) {
     !!!check_missing_exprs
 
     # Tracks state of `{domain}.enable` and `.disable` commands
-    private$event_manager$track_domain_event_activation(!!method_name)
+    private$event_manager$track_domain_manual_event_activation(!!method_name)
 
     msg <- list(
       method = !!method_name,

--- a/README.Rmd
+++ b/README.Rmd
@@ -1070,13 +1070,9 @@ Currently setting custom headers requires a little extra work because it require
 
 ```R
 b <- ChromoteSession$new()
-# Currently need to manually enable Network domain notifications. Calling
-# b$Network$enable() would do it, but calling it directly will bypass the
-# callback counting and the notifications could get automatically disabled by a
-# different Network event. We'll enable notifications for the Network domain by
-# listening for a particular event. We'll also store a callback that will
-# decrement the callback counter, so that we can disable notifications ater.
-disable_network_notifications <- b$Network$responseReceived(function (msg) NULL)
+# Manually enable Network domain notifications
+b$Network$enable()
+
 b$Network$setExtraHTTPHeaders(headers = list(
   foo = "bar",
   header1 = "value1"
@@ -1096,10 +1092,9 @@ b$Network$setExtraHTTPHeaders(headers = list(a=1)[0])
 b$Page$navigate("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
-
-# Disable extra headers entirely, by decrementing Network callback counter,
-# which will disable Network notifications.
-disable_network_notifications()
+# Disable extra headers entirely, disabling Network notifications. (If you call
+# a Network command, chromote's auto_events will re-enable notifications.)
+b$Network$disable()
 ```
 
 ### Custom User-Agent

--- a/README.md
+++ b/README.md
@@ -1365,13 +1365,9 @@ streamline things so that it will happen automatically.
 
 ``` r
 b <- ChromoteSession$new()
-# Currently need to manually enable Network domain notifications. Calling
-# b$Network$enable() would do it, but calling it directly will bypass the
-# callback counting and the notifications could get automatically disabled by a
-# different Network event. We'll enable notifications for the Network domain by
-# listening for a particular event. We'll also store a callback that will
-# decrement the callback counter, so that we can disable notifications ater.
-disable_network_notifications <- b$Network$responseReceived(function (msg) NULL)
+# Manually enable Network domain notifications
+b$Network$enable()
+
 b$Network$setExtraHTTPHeaders(headers = list(
   foo = "bar",
   header1 = "value1"
@@ -1391,10 +1387,9 @@ b$Network$setExtraHTTPHeaders(headers = list(a=1)[0])
 b$Page$navigate("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
-
-# Disable extra headers entirely, by decrementing Network callback counter,
-# which will disable Network notifications.
-disable_network_notifications()
+# Disable extra headers entirely, disabling Network notifications. (If you call
+# a Network command, chromote's auto_events will re-enable notifications.)
+b$Network$disable()
 ```
 
 ### Custom User-Agent


### PR DESCRIPTION
Fixes #144

The crux of #144 is that, if users call `session${Domain}$enable()` themselves, chromote will not know that enable was called and will **also** internally call the `{domain}.enable` command when `auto_events = TRUE`, potentially undoing or stomping on the user's `$enable()` call.

To fix this, we essentially track when `$enable()` was called manually and avoid calling it ourselves if it was already called by the user. In other words, `auto_events` are disabled for a domain between two user calls to `$enable()` and `$disable()`.

## Before

Notice that when `session$Fetch$requestPaused()` is called, chromote automatically calles `Fetch$enable()` even though Fetch events were already enabled.

``` r
pkgload::load_all()
#> ℹ Loading chromote

local_chrome_version(binary = "chrome-headless-shell")
#> chromote will now use version 135.0.7000.0 of `chrome-headless-shell` for
#> mac-arm64.

chrome <- Chromote$new()
chrome$debug_messages(TRUE)

session <- ChromoteSession$new(parent = chrome)
#> SEND {"method":"Target.createTarget","params":{"url":"about:blank","width":992,"height":1323},"id":1}
#> RECV {"id":1,"result":{"targetId":"815A268DA9C1B58297E52BADF9212BE8"}}
#> SEND {"method":"Target.attachToTarget","params":{"targetId":"815A268DA9C1B58297E52BADF9212BE8","flatten":true},"id":2}
#> RECV {"method":"Target.attachedToTarget","params":{"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A","targetInfo":{"targetId":"815A268DA9C1B58297E52BADF9212BE8","type":"page","title":"about:blank","url":"about:blank","attached":true,"canAccessOpener":false,"browserContextId":"B609BF2F26451197F34E1BD130E06163"},"waitingForDebugger":false}}
#> RECV {"id":2,"result":{"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}}
#> SEND {"method":"Runtime.evaluate","params":{"expression":"window.devicePixelRatio"},"id":3,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":3,"result":{"result":{"type":"number","value":1,"description":"1"}},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> Callbacks for Inspector++: 1
#> Enabling events for Inspector
#> SEND {"method":"Inspector.enable","params":[],"id":4,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":4,"result":{},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}

session$Fetch$enable(
  patterns = list(
    list(urlPattern = "*")
  ),
  handleAuthRequests = TRUE
)
#> SEND {"method":"Fetch.enable","params":{"patterns":[{"urlPattern":"*"}],"handleAuthRequests":true},"id":5,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":5,"result":{},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> named list()

session$Fetch$requestPaused(
  callback_ = function(x) session$Fetch$continueRequest(requestId = x$requestId)
)
#> Callbacks for Fetch++: 1
#> Enabling events for Fetch
#> SEND {"method":"Fetch.enable","params":{},"id":6,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":6,"result":{},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
```

## After

With this PR, `Fetch.enable` is not sent a second time becaue we know that the user has already called `Fetch$enable()`.

``` r
pkgload::load_all()
#> ℹ Loading chromote

local_chrome_version(binary = "chrome-headless-shell")
#> chromote will now use version 135.0.7000.0 of `chrome-headless-shell` for
#> mac-arm64.

chrome <- Chromote$new()
chrome$debug_messages(TRUE)

session <- ChromoteSession$new(parent = chrome)
#> SEND {"method":"Target.createTarget","params":{"url":"about:blank","width":992,"height":1323},"id":1}
#> RECV {"id":1,"result":{"targetId":"C47B0B5E9862C2B2C0417C72E2D2EBDD"}}
#> SEND {"method":"Target.attachToTarget","params":{"targetId":"C47B0B5E9862C2B2C0417C72E2D2EBDD","flatten":true},"id":2}
#> RECV {"method":"Target.attachedToTarget","params":{"sessionId":"E093DC262074FD6FC1B7594C0BE1167D","targetInfo":{"targetId":"C47B0B5E9862C2B2C0417C72E2D2EBDD","type":"page","title":"about:blank","url":"about:blank","attached":true,"canAccessOpener":false,"browserContextId":"FF126BB50DD88E974063C587B434CA27"},"waitingForDebugger":false}}
#> RECV {"id":2,"result":{"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}}
#> SEND {"method":"Runtime.evaluate","params":{"expression":"window.devicePixelRatio"},"id":3,"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}
#> RECV {"id":3,"result":{"result":{"type":"number","value":1,"description":"1"}},"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}
#> Callbacks for Inspector++: 1
#> Enabling events for Inspector
#> SEND {"method":"Inspector.enable","params":[],"id":4,"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}
#> RECV {"id":4,"result":{},"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}

session$Fetch$enable(
  patterns = list(
    list(urlPattern = "*")
  ),
  handleAuthRequests = TRUE
)
#> SEND {"method":"Fetch.enable","params":{"patterns":[{"urlPattern":"*"}],"handleAuthRequests":true},"id":5,"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}
#> RECV {"id":5,"result":{},"sessionId":"E093DC262074FD6FC1B7594C0BE1167D"}
#> named list()

session$Fetch$requestPaused(
  callback_ = function(x) session$Fetch$continueRequest(requestId = x$requestId)
)
#> Callbacks for Fetch++: 1
```

## Notes

This PR also accounts for the case when the user calls `$disable()` at any point between calling a command with an event-driven callback and receiving the event. In these cases, we won't be able to decrement the callback count because new events aren't coming in, so rather than starting auto events again when we go from 0 → 1 callbacks, we now re-start auto events when we go from `n` → `n + 1` callbacks, where `n` is the callback count when `$disable()` was called.