### PR TITLE
feat(ChromoteSession): Add `$set_viewport_size()` and `$get_viewport_size()` helper methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * `ChromoteSession$new()` now sets `width` and `height` using [Emulation.setDeviceMetricsOverride](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride), which works for all Chrome binaries and versions. This fixes an issue with `width` and `height` being ignored for Chrome versions 128-133. (#205)
 
+* `ChromoteSession` gains two new helper methods: `$set_viewport_size()` and `$get_viewport_size()`. These methods allow you to change the viewport size – effectively the virtual window size for a page – or to get the current viewport size. If you previously relied on `$Emulation$setVisibleSize()` (now a deprecated method in the Chrome DevTools Protocol), `$set_viewport_size()` is a good replacement as it uses [Emulation.setDeviceMetricsOverride](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride) instead. (#206)
+
 # chromote 0.4.0
 
 * Chrome v132 and later no longer support [old headless mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome). As such, `chromote` no longer defaults to using `--headless=old` and now uses `--headless` when running Chrome. You can still use the `chromote.headless` option or `CHROMOTE_HEADLESS` environment variable to configure the `--headless` flag if you're using an older version of Chrome. (#187)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -336,7 +336,7 @@ ChromoteSession <- R6Class(
           width = width,
           height = height,
           deviceScaleFactor = zoom %||% private$pixel_ratio,
-          mobile = mobile %||% private$is_mobile,
+          mobile = mobile %||% private$is_mobile %||% FALSE,
           wait_ = FALSE
         )
       })$then(function(value) {

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -695,9 +695,12 @@ ChromoteSession <- R6Class(
     session_is_active = NULL,
     target_is_active = NULL,
     event_manager = NULL,
-    pixel_ratio = NULL,
     auto_events = NULL,
     init_promise_ = NULL,
+
+    # Updated when `Emulation.setDeviceMetricsOverride` is called
+    pixel_ratio = NULL,
+    is_mobile = NULL,
 
     register_event_listener = function(event, callback = NULL, timeout = NULL) {
       self$check_active()

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -260,6 +260,92 @@ ChromoteSession <- R6Class(
       }
     },
 
+    #' @description Get the viewport size
+    #'
+    #' @param wait_ If `FALSE`, return a [promises::promise()] of a new
+    #'   `ChromoteSession` object. Otherwise, block during initialization, and
+    #'   return a `ChromoteSession` object directly.
+    #'
+    #' @return Returns a list with values `width`, `height`, `zoom`
+    #'   and `mobile`. See `$set_viewport_size()` for more details.
+    get_viewport_size = function(wait_ = TRUE) {
+      check_bool(wait_)
+
+      p <- self$Runtime$evaluate(
+        "(() => ({width: window.innerWidth, height: window.innerHeight }))()",
+        returnByValue = TRUE,
+        wait_ = FALSE
+      )$then(function(value) {
+        list(
+          width = value$result$value$width,
+          height = value$result$value$height,
+          zoom = private$pixel_ratio,
+          mobile = private$is_mobile
+        )
+      })
+
+      if (wait_) self$wait_for(p) else p
+    },
+
+    #' @description Set the viewport size
+    #'
+    #' Each ChromoteSession is associated with a page that may be one page open
+    #' in a browser window among many. Each page can have its own viewport size,
+    #' that can be thought of like the window size for that page.
+    #'
+    #' This function uses the
+    #' [Emulation.setDeviceMetricsOverride](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride)
+    #' command to set the viewport size. If you need more granular control or
+    #' access to additional settings, use
+    #' `$Emulation$setDeviceMetricsOverride()`.
+    #'
+    #' @param width,height Width and height of the new window in integer pixel
+    #'   values.
+    #' @param zoom The zoom level of displayed content on a device, where a
+    #'   value of 1 indicates normal size, greater than 1 indicates zoomed in,
+    #'   and less than 1 indicates zoomed out.
+    #' @param mobile Whether to emulate mobile device. When `TRUE`, Chrome
+    #'   updates settings to emulate browsing on a mobile phone; this includes
+    #'   viewport meta tag, overlay scrollbars, text autosizing and more. The
+    #'   default is `FALSE`.
+    #' @param wait_ If `FALSE`, return a [promises::promise()] of a new
+    #'   `ChromoteSession` object. Otherwise, block during initialization, and
+    #'   return a `ChromoteSession` object directly.
+    #'
+    #' @return Invisibly returns the previous viewport dimensions so that you
+    #'   can restore the viewport size, if desired.
+    set_viewport_size = function(
+      width,
+      height,
+      zoom = NULL,
+      mobile = NULL,
+      wait_ = TRUE
+    ) {
+      check_number_whole(width)
+      check_number_whole(height)
+      check_number_decimal(zoom, allow_null = TRUE)
+      check_bool(mobile, allow_null = TRUE)
+      check_bool(wait_)
+
+      prev_bounds <- NULL
+
+      p <- self$get_viewport_size(wait_ = FALSE)$then(function(value) {
+        prev_bounds <<- value
+
+        self$Emulation$setDeviceMetricsOverride(
+          width = width,
+          height = height,
+          deviceScaleFactor = zoom %||% private$pixel_ratio,
+          mobile = mobile %||% private$is_mobile,
+          wait_ = FALSE
+        )
+      })$then(function(value) {
+        invisible(prev_bounds)
+      })
+
+      if (wait_) self$wait_for(p) else p
+    },
+
     #' @description Take a PNG screenshot
     #'
     #' ## Examples

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -121,6 +121,9 @@ gen_command_body <- function(method_name, params) {
       })
     }
 
+  # As of 2025-02-07, it's not possible to query CDP to determine if the value
+  # of `mobile` in the device metrics override, so we need to track its value
+  # through any calls to `Emulation.setDeviceMetricsOverride`.
   track_device_override_mobile <-
     if (identical(method_name, "Emulation.setDeviceMetricsOverride")) {
       expr({

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -121,6 +121,16 @@ gen_command_body <- function(method_name, params) {
       })
     }
 
+  track_device_override_mobile <-
+    if (identical(method_name, "Emulation.setDeviceMetricsOverride")) {
+      expr({
+        private$pixel_ratio <- deviceScaleFactor
+        private$is_mobile <- mobile
+      })
+    } else {
+      expr({}) # fmt: skip
+    }
+
   # Construct parameters for message
   param_list <- lapply(params, function(param) {
     as.symbol(param$name)
@@ -143,6 +153,8 @@ gen_command_body <- function(method_name, params) {
 
     # Check for missing non-optional args
     !!!check_missing_exprs
+
+    !!!track_device_override_mobile
 
     msg <- list(
       method = !!method_name,

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -124,8 +124,8 @@ gen_command_body <- function(method_name, params) {
   track_device_override_mobile <-
     if (identical(method_name, "Emulation.setDeviceMetricsOverride")) {
       expr({
-        private$pixel_ratio <- deviceScaleFactor
-        private$is_mobile <- mobile
+        private$pixel_ratio <- !!sym("deviceScaleFactor")
+        private$is_mobile <- !!sym("mobile")
       })
     } else {
       expr({}) # fmt: skip

--- a/README.Rmd
+++ b/README.Rmd
@@ -979,10 +979,10 @@ b$Page$navigate("https://www.r-project.org/")
 b$screenshot("narrow.png")
 ```
 
-With an existing `ChromoteSession`, you can set the size with `b$Emulation$setVisibleSize()`:
+With an existing `ChromoteSession`, you can set the size with `b$set_viewport_sze()`:
 
 ```R
-b$Emulation$setVisibleSize(width=1600, height=900)
+b$set_viewport_size(width = 1600, height = 900)
 b$screenshot("wide.png")
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -979,7 +979,7 @@ b$Page$navigate("https://www.r-project.org/")
 b$screenshot("narrow.png")
 ```
 
-With an existing `ChromoteSession`, you can set the size with `b$set_viewport_sze()`:
+With an existing `ChromoteSession`, you can set the size with `b$set_viewport_size()`:
 
 ```R
 b$set_viewport_size(width = 1600, height = 900)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+
 <!-- Do not run R chunks that print any session information.
      This produces unstable output.
      Instead, copy output from a local execution
@@ -1269,10 +1270,10 @@ b$screenshot("narrow.png")
 ```
 
 With an existing `ChromoteSession`, you can set the size with
-`b$Emulation$setVisibleSize()`:
+`b$set_viewport_sze()`:
 
 ``` r
-b$Emulation$setVisibleSize(width=1600, height=900)
+b$set_viewport_size(width = 1600, height = 900)
 b$screenshot("wide.png")
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
 <!-- Do not run R chunks that print any session information.
      This produces unstable output.
      Instead, copy output from a local execution

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+
 <!-- Do not run R chunks that print any session information.
      This produces unstable output.
      Instead, copy output from a local execution
@@ -1269,7 +1270,7 @@ b$screenshot("narrow.png")
 ```
 
 With an existing `ChromoteSession`, you can set the size with
-`b$set_viewport_sze()`:
+`b$set_viewport_size()`:
 
 ``` r
 b$set_viewport_size(width = 1600, height = 900)

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -29,6 +29,8 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-new}{\code{ChromoteSession$new()}}
 \item \href{#method-ChromoteSession-view}{\code{ChromoteSession$view()}}
 \item \href{#method-ChromoteSession-close}{\code{ChromoteSession$close()}}
+\item \href{#method-ChromoteSession-get_viewport_size}{\code{ChromoteSession$get_viewport_size()}}
+\item \href{#method-ChromoteSession-set_viewport_size}{\code{ChromoteSession$set_viewport_size()}}
 \item \href{#method-ChromoteSession-screenshot}{\code{ChromoteSession$screenshot()}}
 \item \href{#method-ChromoteSession-screenshot_pdf}{\code{ChromoteSession$screenshot_pdf()}}
 \item \href{#method-ChromoteSession-new_session}{\code{ChromoteSession$new_session()}}
@@ -170,6 +172,80 @@ when the \code{ChromoteSession} is closed. Otherwise, block until the
 \code{ChromoteSession} has closed.}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-get_viewport_size"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-get_viewport_size}{}}}
+\subsection{Method \code{get_viewport_size()}}{
+Get the viewport size
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_viewport_size(wait_ = TRUE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{wait_}}{If \code{FALSE}, return a \code{\link[promises:promise]{promises::promise()}} of a new
+\code{ChromoteSession} object. Otherwise, block during initialization, and
+return a \code{ChromoteSession} object directly.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Returns a list with values \code{width}, \code{height}, \code{zoom}
+and \code{mobile}. See \verb{$set_viewport_size()} for more details.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-set_viewport_size"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-set_viewport_size}{}}}
+\subsection{Method \code{set_viewport_size()}}{
+Set the viewport size
+
+Each ChromoteSession is associated with a page that may be one page open
+in a browser window among many. Each page can have its own viewport size,
+that can be thought of like the window size for that page.
+
+This function uses the
+\href{https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride}{Emulation.setDeviceMetricsOverride}
+command to set the viewport size. If you need more granular control or
+access to additional settings, use
+\verb{$Emulation$setDeviceMetricsOverride()}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$set_viewport_size(
+  width,
+  height,
+  zoom = NULL,
+  mobile = NULL,
+  wait_ = TRUE
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{width, height}}{Width and height of the new window in integer pixel
+values.}
+
+\item{\code{zoom}}{The zoom level of displayed content on a device, where a
+value of 1 indicates normal size, greater than 1 indicates zoomed in,
+and less than 1 indicates zoomed out.}
+
+\item{\code{mobile}}{Whether to emulate mobile device. When \code{TRUE}, Chrome
+updates settings to emulate browsing on a mobile phone; this includes
+viewport meta tag, overlay scrollbars, text autosizing and more. The
+default is \code{FALSE}.}
+
+\item{\code{wait_}}{If \code{FALSE}, return a \code{\link[promises:promise]{promises::promise()}} of a new
+\code{ChromoteSession} object. Otherwise, block during initialization, and
+return a \code{ChromoteSession} object directly.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Invisibly returns the previous viewport dimensions so that you
+can restore the viewport size, if desired.
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-chromote_session.R
+++ b/tests/testthat/test-chromote_session.R
@@ -7,3 +7,21 @@ test_that("respawning preserves targetId and auto_events", {
   expect_equal(sess1$get_target_id(), sess2$get_target_id())
   expect_equal(sess1$get_auto_events(), sess2$get_auto_events())
 })
+
+test_that("ChromoteSession track metrics from `Emulation.setDeviceMetricsOverride`", {
+  skip_if_no_chromote()
+
+  page <- ChromoteSession$new(mobile = TRUE)
+  withr::defer(page$close())
+
+  expect_true(page$.__enclos_env__$private$is_mobile)
+
+  page$Emulation$setDeviceMetricsOverride(
+    600,
+    600,
+    deviceScaleFactor = 2,
+    mobile = FALSE
+  )
+  expect_false(page$.__enclos_env__$private$is_mobile)
+  expect_equal(page$.__enclos_env__$private$pixel_ratio, 2)
+})

--- a/tests/testthat/test-chromote_session.R
+++ b/tests/testthat/test-chromote_session.R
@@ -25,3 +25,40 @@ test_that("ChromoteSession track metrics from `Emulation.setDeviceMetricsOverrid
   expect_false(page$.__enclos_env__$private$is_mobile)
   expect_equal(page$.__enclos_env__$private$pixel_ratio, 2)
 })
+
+test_that("ChromoteSession gets and sets viewport size", {
+  skip_if_no_chromote()
+  skip_if_offline()
+
+  page <- ChromoteSession$new(width = 400, height = 800, mobile = TRUE)
+  # viewport requires an active page
+  page$Page$navigate("https://example.com")
+  withr::defer(page$close())
+
+  init_size <- list(
+    width = 400,
+    height = 800,
+    zoom = page$.__enclos_env__$private$pixel_ratio,
+    mobile = TRUE
+  )
+
+  expect_equal(
+    page$get_viewport_size(),
+    init_size
+  )
+
+  expect_equal(
+    page$set_viewport_size(500, 900, zoom = 2, mobile = FALSE),
+    init_size # returned invisibly
+  )
+
+  expect_equal(
+    page$get_viewport_size(),
+    list(
+      width = 500,
+      height = 900,
+      zoom = 2,
+      mobile = FALSE
+    )
+  )
+})


### PR DESCRIPTION
Adds helper methods to get and set the viewport size

``` r
pkgload::load_all("~/work/rstudio/chromote")
#> ℹ Loading chromote

page <- ChromoteSession$new(width = 400, height = 800, mobile = TRUE)
# viewport requires an active page
page$Page$navigate("https://example.com")

str(page$get_viewport_size())
#> List of 4
#>  $ width : int 400
#>  $ height: int 800
#>  $ zoom  : int 1
#>  $ mobile: logi TRUE

old <- page$set_viewport_size(
  width = 500,
  height = 800,
  zoom = 2,
  mobile = FALSE
)
str(old)
#> List of 4
#>  $ width : int 400
#>  $ height: int 800
#>  $ zoom  : int 1
#>  $ mobile: logi TRUE

str(page$get_viewport_size())
#> List of 4
#>  $ width : int 500
#>  $ height: int 800
#>  $ zoom  : num 2
#>  $ mobile: logi FALSE
```