### PR TITLE
feat: `auto_events_enable_args` for ChromoteSession and Chromote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Suggests:
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: TRUE
+Config/testthat/start-first: chromote_session
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -28,21 +28,14 @@ Chromote <- R6Class(
     #' @param multi_session Should multiple sessions be allowed?
     #' @param auto_events If `TRUE`, enable automatic event enabling/disabling;
     #'   if `FALSE`, disable automatic event enabling/disabling.
-    #' @param auto_events_enable_args A list of arguments, by domain, to be used
-    #'   when calling `{Domain}.enable` when `auto_events = TRUE`. For example,
-    #'   Use `list(Fetch = list(handleAuthRequests = TRUE))` to use
-    #'   `Fetch$enable(handleAuthRequests = TRUE)` when enabling `Fetch` events.
     initialize = function(
       browser = Chrome$new(),
       multi_session = TRUE,
-      auto_events = TRUE,
-      auto_events_enable_args = list()
+      auto_events = TRUE
     ) {
       private$browser <- browser
       private$auto_events <- auto_events
       private$multi_session <- multi_session
-
-      check_auto_events_enable_args(auto_events_enable_args)
 
       private$command_callbacks <- fastmap()
 
@@ -63,13 +56,6 @@ Chromote <- R6Class(
       list2env(self$protocol, self)
 
       private$event_manager <- EventManager$new(self)
-
-      for (domain in names(auto_events_enable_args)) {
-        self$auto_events_enable_args(
-          domain,
-          !!!auto_events_enable_args[[domain]]
-        )
-      }
 
       self$wait_for(p)
 
@@ -156,7 +142,7 @@ Chromote <- R6Class(
     #' @param domain A command domain, e.g. `"Fetch"`.
     #' @param ... Arguments to use for auto-events for the domain. If not
     #'   provided, returns the argument values currently in place for the
-    #'   domain.
+    #'   domain. Use `NULL` to clear the enable arguments for a domain.
     auto_events_enable_args = function(domain, ...) {
       dots <- dots_list(..., .named = TRUE)
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -53,14 +53,6 @@ ChromoteSession <- R6Class(
     #'   from the parent `Chromote` object. If `TRUE`, enable automatic
     #'   event enabling/disabling; if `FALSE`, disable automatic event
     #'   enabling/disabling.
-    #' @param auto_events_enable_args A list of arguments, by domain, to be used
-    #'   when calling `{Domain}.enable` when `auto_events = TRUE`. For example,
-    #'   Use `list(Fetch = list(handleAuthRequests = TRUE))` to use
-    #'   `Fetch$enable(handleAuthRequests = TRUE)` when enabling `Fetch` events.
-    #'   By default, uses domain-specific arguments from the parent `Chromote`
-    #'   object; `ChromoteSession` arguments take precedence over parent
-    #'   arguments.
-    #'
     #' @return A new `ChromoteSession` object.
     initialize = function(
       parent = default_chromote_object(),
@@ -69,7 +61,6 @@ ChromoteSession <- R6Class(
       targetId = NULL,
       wait_ = TRUE,
       auto_events = NULL,
-      auto_events_enable_args = list(),
       mobile = FALSE
     ) {
       check_number_whole(width)
@@ -77,7 +68,6 @@ ChromoteSession <- R6Class(
       check_logical(auto_events, allow_null = TRUE)
       check_logical(mobile)
       check_logical(wait_)
-      check_auto_events_enable_args(auto_events_enable_args)
 
       self$parent <- parent
       lockBinding("parent", self) # do not allow `$parent` to be set!
@@ -138,13 +128,6 @@ ChromoteSession <- R6Class(
       private$event_manager <- EventManager$new(self)
       private$session_is_active <- TRUE
       private$target_is_active <- TRUE
-
-      for (domain in names(auto_events_enable_args)) {
-        self$auto_events_enable_args(
-          domain,
-          !!!auto_events_enable_args[[domain]]
-        )
-      }
 
       # Find pixelRatio for screenshots
       p <- p$then(function(value) {
@@ -715,14 +698,18 @@ ChromoteSession <- R6Class(
     #'
     #'   # Get current `Fetch.enable` args
     #'   b$auto_events_enable_args("Fetch")
+    #'
     #'   # Update the `Fetch.enable` args
     #'   b$auto_events_enable_args("Fetch", handleAuthRequests = FALSE)
+    #'
+    #'   # Reset `Fetch.enable` args
+    #'   b$auto_events_enable_args("Fetch", NULL)
     #' }
     #'
     #' @param domain A command domain, e.g. `"Fetch"`.
     #' @param ... Arguments to use for auto-events for the domain. If not
     #'   provided, returns the argument values currently in place for the
-    #'   domain.
+    #'   domain. Use `NULL` to clear the enable arguments for a domain.
     auto_events_enable_args = function(domain, ...) {
       dots <- dots_list(..., .named = TRUE)
 

--- a/R/event_manager.R
+++ b/R/event_manager.R
@@ -150,7 +150,11 @@ EventManager <- R6Class(
           isTRUE(private$event_enable_domains[[domain]])
       ) {
         private$session$debug_log("Enabling events for ", domain)
-        private$session[[domain]]$enable()
+        args <- private$session$auto_events_enable_args(domain)
+        exec(
+          private$session[[domain]]$enable,
+          !!!args
+        )
       }
 
       invisible(private$event_callback_counts[[domain]])
@@ -181,3 +185,67 @@ EventManager <- R6Class(
     }
   )
 )
+
+# These functions power `$auto_events_enable_args()` for both `Chromote` and
+# `ChromoteSession`.
+check_auto_events_enable_args <- function(args) {
+  error_msg <- "{.arg auto_events_enable_args} must be a named list of domains and associated arguments for the {.code enable} command."
+
+  if (!is.list(args)) {
+    cli::cli_abort(error_msg, call = parent.frame())
+  }
+
+  if (length(args) > 0 && any(!nzchar(names2(args)))) {
+    cli::cli_abort(error_msg, call = parent.frame())
+  }
+
+  invisible(args)
+}
+
+get_auto_events_enable_args <- function(private, domain, parent = NULL) {
+  session_args <- private$auto_events_enable_args[[domain]]
+  if (!is.null(session_args) || is.null(parent)) {
+    return(session_args)
+  }
+
+  return(parent$auto_events_enable_args(domain))
+}
+
+set_auto_events_enable_args <- function(self, private, domain, dots) {
+  # Set enable args for the domain ----
+  if (identical(dots, list("NULL" = NULL))) {
+    # Unset args with `$auto_events_enable_args(domain, NULL)`
+    dots <- NULL
+  }
+
+  if (!is_function(self[[domain]]$enable)) {
+    cli::cli_abort(
+      "{.field {domain}} does not have an {.field enable} method.",
+      call = parent.frame()
+    )
+  }
+
+  known_args <- names(fn_fmls(self[[domain]]$enable))
+  unknown_args <- setdiff(names(dots), known_args)
+  if (length(unknown_args)) {
+    cli::cli_abort(
+      c(
+        "{.field {domain}.enable} does not have {cli::qty(unknown_args)}argument{?s}: {.arg {unknown_args}}.",
+        "i" = "Available arguments: {.arg {setdiff(known_args, 'wait_')}}"
+      ),
+      call = parent.frame()
+    )
+  }
+
+  if ("wait_" %in% names(dots)) {
+    cli::cli_warn(
+      "{.arg wait_} cannot be set for {.field {domain}.enable}, ignoring.",
+      call = parent.frame()
+    )
+    dots[["wait_"]] <- NULL
+  }
+
+  old <- self$auto_events_enable_args(domain)
+  private$auto_events_enable_args[[domain]] <- dots
+  invisible(old)
+}

--- a/R/event_manager.R
+++ b/R/event_manager.R
@@ -188,20 +188,6 @@ EventManager <- R6Class(
 
 # These functions power `$auto_events_enable_args()` for both `Chromote` and
 # `ChromoteSession`.
-check_auto_events_enable_args <- function(args) {
-  error_msg <- "{.arg auto_events_enable_args} must be a named list of domains and associated arguments for the {.code enable} command."
-
-  if (!is.list(args)) {
-    cli::cli_abort(error_msg, call = parent.frame())
-  }
-
-  if (length(args) > 0 && any(!nzchar(names2(args)))) {
-    cli::cli_abort(error_msg, call = parent.frame())
-  }
-
-  invisible(args)
-}
-
 get_auto_events_enable_args <- function(private, domain, parent = NULL) {
   session_args <- private$auto_events_enable_args[[domain]]
   if (!is.null(session_args) || is.null(parent)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -281,6 +281,8 @@ $timestamp
 >
 > Note that in asynchronous mode, the behavior is slightly more sophisticated: it maintains a counter of how many outstanding events it is waiting for in a given domain. When that count goes from 0 to 1, it sends the `X.enable` command; when the count goes from 1 to 0, it sends the `X.disable` command. For more information, see the [Async events](#async-events) section.
 >
+> If you need to customize the arguments used by the automatically-run `enable` command, you can use the `auto_events_enable_args` argument of `Chromote$new()` or `ChromoteSession$new()`, or you can adjust the arguments after creating the chromote session with the `$auto_events_enable_args()` method.
+>
 > If you do not want automatic event enabling and disabling, then when creating the ChromoteSession object, use `ChromoteSession$new(auto_events = FALSE)`.
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -281,7 +281,7 @@ $timestamp
 >
 > Note that in asynchronous mode, the behavior is slightly more sophisticated: it maintains a counter of how many outstanding events it is waiting for in a given domain. When that count goes from 0 to 1, it sends the `X.enable` command; when the count goes from 1 to 0, it sends the `X.disable` command. For more information, see the [Async events](#async-events) section.
 >
-> If you need to customize the arguments used by the automatically-run `enable` command, you can use the `auto_events_enable_args` argument of `Chromote$new()` or `ChromoteSession$new()`, or you can adjust the arguments after creating the chromote session with the `$auto_events_enable_args()` method.
+> If you need to customize the arguments used by the automatically-run `enable` command, you can use the `$auto_events_enable_args()` method of a `Chromote` or `ChromoteSession` instance, e.g. `b$auto_events_enable_args("Page", enableFileChooserOpenedEvent = TRUE)`.
 >
 > If you do not want automatic event enabling and disabling, then when creating the ChromoteSession object, use `ChromoteSession$new(auto_events = FALSE)`.
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ value, which looks like this:
 > sends the `X.disable` command. For more information, see the [Async
 > events](#async-events) section.
 >
+> If you need to customize the arguments used by the automatically-run
+> `enable` command, you can use the `auto_events_enable_args` argument
+> of `Chromote$new()` or `ChromoteSession$new()`, or you can adjust the
+> arguments after creating the chromote session with the
+> `$auto_events_enable_args()` method.
+>
 > If you do not want automatic event enabling and disabling, then when
 > creating the ChromoteSession object, use
 > `ChromoteSession$new(auto_events = FALSE)`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
 <!-- Do not run R chunks that print any session information.
      This produces unstable output.
      Instead, copy output from a local execution

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+
 <!-- Do not run R chunks that print any session information.
      This produces unstable output.
      Instead, copy output from a local execution
@@ -339,10 +340,9 @@ value, which looks like this:
 > events](#async-events) section.
 >
 > If you need to customize the arguments used by the automatically-run
-> `enable` command, you can use the `auto_events_enable_args` argument
-> of `Chromote$new()` or `ChromoteSession$new()`, or you can adjust the
-> arguments after creating the chromote session with the
-> `$auto_events_enable_args()` method.
+> `enable` command, you can use the `$auto_events_enable_args()` method
+> of a `Chromote` or `ChromoteSession` instance,
+> e.g. `b$auto_events_enable_args("Page", enableFileChooserOpenedEvent = TRUE)`.
 >
 > If you do not want automatic event enabling and disabling, then when
 > creating the ChromoteSession object, use

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -40,6 +40,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-Chromote-connect}{\code{Chromote$connect()}}
 \item \href{#method-Chromote-view}{\code{Chromote$view()}}
 \item \href{#method-Chromote-get_auto_events}{\code{Chromote$get_auto_events()}}
+\item \href{#method-Chromote-auto_events_enable_args}{\code{Chromote$auto_events_enable_args()}}
 \item \href{#method-Chromote-get_child_loop}{\code{Chromote$get_child_loop()}}
 \item \href{#method-Chromote-wait_for}{\code{Chromote$wait_for()}}
 \item \href{#method-Chromote-new_session}{\code{Chromote$new_session()}}
@@ -64,7 +65,12 @@ wait for a Chrome DevTools Protocol response.}
 \if{latex}{\out{\hypertarget{method-Chromote-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$new(browser = Chrome$new(), multi_session = TRUE, auto_events = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$new(
+  browser = Chrome$new(),
+  multi_session = TRUE,
+  auto_events = TRUE,
+  auto_events_enable_args = list()
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -76,6 +82,11 @@ wait for a Chrome DevTools Protocol response.}
 
 \item{\code{auto_events}}{If \code{TRUE}, enable automatic event enabling/disabling;
 if \code{FALSE}, disable automatic event enabling/disabling.}
+
+\item{\code{auto_events_enable_args}}{A list of arguments, by domain, to be used
+when calling \verb{\{Domain\}.enable} when \code{auto_events = TRUE}. For example,
+Use \code{list(Fetch = list(handleAuthRequests = TRUE))} to use
+\code{Fetch$enable(handleAuthRequests = TRUE)} when enabling \code{Fetch} events.}
 }
 \if{html}{\out{</div>}}
 }
@@ -127,6 +138,29 @@ For internal use only.
 \if{html}{\out{<div class="r">}}\preformatted{Chromote$get_auto_events()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chromote-auto_events_enable_args"></a>}}
+\if{latex}{\out{\hypertarget{method-Chromote-auto_events_enable_args}{}}}
+\subsection{Method \code{auto_events_enable_args()}}{
+Set or retrieve the \code{enable} command arguments for a domain. These
+arguments are used for the \code{enable} command that is called for a domain,
+e.g. \code{Fetch$enable()}, when accessing an event method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$auto_events_enable_args(domain, ...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{domain}}{A command domain, e.g. \code{"Fetch"}.}
+
+\item{\code{...}}{Arguments to use for auto-events for the domain. If not
+provided, returns the argument values currently in place for the
+domain.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chromote-get_child_loop"></a>}}

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -65,12 +65,7 @@ wait for a Chrome DevTools Protocol response.}
 \if{latex}{\out{\hypertarget{method-Chromote-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$new(
-  browser = Chrome$new(),
-  multi_session = TRUE,
-  auto_events = TRUE,
-  auto_events_enable_args = list()
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$new(browser = Chrome$new(), multi_session = TRUE, auto_events = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -82,11 +77,6 @@ wait for a Chrome DevTools Protocol response.}
 
 \item{\code{auto_events}}{If \code{TRUE}, enable automatic event enabling/disabling;
 if \code{FALSE}, disable automatic event enabling/disabling.}
-
-\item{\code{auto_events_enable_args}}{A list of arguments, by domain, to be used
-when calling \verb{\{Domain\}.enable} when \code{auto_events = TRUE}. For example,
-Use \code{list(Fetch = list(handleAuthRequests = TRUE))} to use
-\code{Fetch$enable(handleAuthRequests = TRUE)} when enabling \code{Fetch} events.}
 }
 \if{html}{\out{</div>}}
 }
@@ -157,7 +147,7 @@ e.g. \code{Fetch$enable()}, when accessing an event method.
 
 \item{\code{...}}{Arguments to use for auto-events for the domain. If not
 provided, returns the argument values currently in place for the
-domain.}
+domain. Use \code{NULL} to clear the enable arguments for a domain.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -26,8 +26,12 @@ if (interactive()) {
 
   # Get current `Fetch.enable` args
   b$auto_events_enable_args("Fetch")
+
   # Update the `Fetch.enable` args
   b$auto_events_enable_args("Fetch", handleAuthRequests = FALSE)
+
+  # Reset `Fetch.enable` args
+  b$auto_events_enable_args("Fetch", NULL)
 }
 
 }
@@ -99,7 +103,6 @@ if (interactive()) b$view()
   targetId = NULL,
   wait_ = TRUE,
   auto_events = NULL,
-  auto_events_enable_args = list(),
   mobile = FALSE
 )}\if{html}{\out{</div>}}
 }
@@ -127,14 +130,6 @@ return a \code{ChromoteSession} object directly.}
 from the parent \code{Chromote} object. If \code{TRUE}, enable automatic
 event enabling/disabling; if \code{FALSE}, disable automatic event
 enabling/disabling.}
-
-\item{\code{auto_events_enable_args}}{A list of arguments, by domain, to be used
-when calling \verb{\{Domain\}.enable} when \code{auto_events = TRUE}. For example,
-Use \code{list(Fetch = list(handleAuthRequests = TRUE))} to use
-\code{Fetch$enable(handleAuthRequests = TRUE)} when enabling \code{Fetch} events.
-By default, uses domain-specific arguments from the parent \code{Chromote}
-object; \code{ChromoteSession} arguments take precedence over parent
-arguments.}
 
 \item{\code{mobile}}{Whether to emulate mobile device. When \code{TRUE}, Chrome
 updates settings to emulate browsing on a mobile phone; this includes
@@ -684,7 +679,7 @@ e.g. \code{Fetch$enable()}, when accessing an event method.
 
 \item{\code{...}}{Arguments to use for auto-events for the domain. If not
 provided, returns the argument values currently in place for the
-domain.}
+domain. Use \code{NULL} to clear the enable arguments for a domain.}
 }
 \if{html}{\out{</div>}}
 }
@@ -699,8 +694,12 @@ domain.}
 
   # Get current `Fetch.enable` args
   b$auto_events_enable_args("Fetch")
+
   # Update the `Fetch.enable` args
   b$auto_events_enable_args("Fetch", handleAuthRequests = FALSE)
+
+  # Reset `Fetch.enable` args
+  b$auto_events_enable_args("Fetch", NULL)
 }
 
 }

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -11,6 +11,26 @@ which is a browser window/tab or an iframe.
 A single target can potentially have more than one session connected to it,
 but this is not currently supported by chromote.
 }
+\examples{
+
+## ------------------------------------------------
+## Method `ChromoteSession$auto_events_enable_args`
+## ------------------------------------------------
+
+if (interactive()) {
+  b <- ChromoteSession$new(
+    auto_events_enable_args = list(
+      Fetch = list(handleAuthRequests = TRUE)
+    )
+  )
+
+  # Get current `Fetch.enable` args
+  b$auto_events_enable_args("Fetch")
+  # Update the `Fetch.enable` args
+  b$auto_events_enable_args("Fetch", handleAuthRequests = FALSE)
+}
+
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -42,6 +62,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-get_child_loop}{\code{ChromoteSession$get_child_loop()}}
 \item \href{#method-ChromoteSession-send_command}{\code{ChromoteSession$send_command()}}
 \item \href{#method-ChromoteSession-get_auto_events}{\code{ChromoteSession$get_auto_events()}}
+\item \href{#method-ChromoteSession-auto_events_enable_args}{\code{ChromoteSession$auto_events_enable_args()}}
 \item \href{#method-ChromoteSession-invoke_event_callbacks}{\code{ChromoteSession$invoke_event_callbacks()}}
 \item \href{#method-ChromoteSession-mark_closed}{\code{ChromoteSession$mark_closed()}}
 \item \href{#method-ChromoteSession-is_active}{\code{ChromoteSession$is_active()}}
@@ -78,6 +99,7 @@ if (interactive()) b$view()
   targetId = NULL,
   wait_ = TRUE,
   auto_events = NULL,
+  auto_events_enable_args = list(),
   mobile = FALSE
 )}\if{html}{\out{</div>}}
 }
@@ -105,6 +127,14 @@ return a \code{ChromoteSession} object directly.}
 from the parent \code{Chromote} object. If \code{TRUE}, enable automatic
 event enabling/disabling; if \code{FALSE}, disable automatic event
 enabling/disabling.}
+
+\item{\code{auto_events_enable_args}}{A list of arguments, by domain, to be used
+when calling \verb{\{Domain\}.enable} when \code{auto_events = TRUE}. For example,
+Use \code{list(Fetch = list(handleAuthRequests = TRUE))} to use
+\code{Fetch$enable(handleAuthRequests = TRUE)} when enabling \code{Fetch} events.
+By default, uses domain-specific arguments from the parent \code{Chromote}
+object; \code{ChromoteSession} arguments take precedence over parent
+arguments.}
 
 \item{\code{mobile}}{Whether to emulate mobile device. When \code{TRUE}, Chrome
 updates settings to emulate browsing on a mobile phone; this includes
@@ -633,6 +663,49 @@ Resolved \code{auto_events} value.
 For internal use only.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$get_auto_events()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-auto_events_enable_args"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-auto_events_enable_args}{}}}
+\subsection{Method \code{auto_events_enable_args()}}{
+Set or retrieve the \code{enable} command arguments for a domain. These
+arguments are used for the \code{enable} command that is called for a domain,
+e.g. \code{Fetch$enable()}, when accessing an event method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$auto_events_enable_args(domain, ...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{domain}}{A command domain, e.g. \code{"Fetch"}.}
+
+\item{\code{...}}{Arguments to use for auto-events for the domain. If not
+provided, returns the argument values currently in place for the
+domain.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{if (interactive()) {
+  b <- ChromoteSession$new(
+    auto_events_enable_args = list(
+      Fetch = list(handleAuthRequests = TRUE)
+    )
+  )
+
+  # Get current `Fetch.enable` args
+  b$auto_events_enable_args("Fetch")
+  # Update the `Fetch.enable` args
+  b$auto_events_enable_args("Fetch", handleAuthRequests = FALSE)
+}
+
+}
+\if{html}{\out{</div>}}
+
 }
 
 }

--- a/tests/testthat/_snaps/chromote_session.md
+++ b/tests/testthat/_snaps/chromote_session.md
@@ -1,0 +1,33 @@
+# ChromoteSession auto_events_enable_args errors
+
+    Code
+      ChromoteSession$new(auto_events_enable_args = NULL)
+    Condition
+      Error in `initialize()`:
+      ! `auto_events_enable_args` must be a named list of domains and associated arguments for the `enable` command.
+
+---
+
+    Code
+      ChromoteSession$new(auto_events_enable_args = list("also bad"))
+    Condition
+      Error in `initialize()`:
+      ! `auto_events_enable_args` must be a named list of domains and associated arguments for the `enable` command.
+
+---
+
+    Code
+      ChromoteSession$new(auto_events_enable_args = list(Browser = list(no_enable = TRUE)))
+    Condition
+      Error in `self$auto_events_enable_args()`:
+      ! Browser does not have an enable method.
+
+---
+
+    Code
+      ChromoteSession$new(auto_events_enable_args = list(Animation = list(bad = TRUE)))
+    Condition
+      Error in `self$auto_events_enable_args()`:
+      ! Animation.enable does not have argument: `bad`.
+      i Available arguments: `callback_`, `error_`, and `timeout_`
+


### PR DESCRIPTION
This is a completely different approach to solving #144 and replaces #207.

Rather than trying to track manual `$enable()` and `$disable()` calls, which we've found to be quite tricky to get right, the approach taken in this PR is to store arguments that should be used for the automatic `$enable()` events, leaving the entire auto-events lifecycle alone.

The pattern in #144 looks like this:

```r
chrome <- Chromote$new()
chrome$debug_messages(TRUE)

session <- ChromoteSession$new(parent = chrome)
#> [...clipped...]

session$Fetch$enable(
  patterns = list(
    list(urlPattern = "*")
  ),
  handleAuthRequests = TRUE
)
#> SEND {"method":"Fetch.enable","params":{"patterns":[{"urlPattern":"*"}],"handleAuthRequests":true},"id":5,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":5,"result":{},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> named list()

session$Fetch$requestPaused(
  callback_ = function(x) session$Fetch$continueRequest(requestId = x$requestId)
)
#> Callbacks for Fetch++: 1
#> Enabling events for Fetch
#> SEND {"method":"Fetch.enable","params":{},"id":6,"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
#> RECV {"id":6,"result":{},"sessionId":"C4B51F2AE8CF5BFF9CD8A33D82B83D3A"}
```

After this PR, users would either set `auto_events_enable_args` when creating the `Chromote` or `ChromoteSession` objects, or with a call to the `$auto_events_enable_args()` method

``` r
pkgload::load_all()
#> ℹ Loading chromote

chrome <- Chromote$new()
chrome$debug_messages(TRUE)

session <- ChromoteSession$new(parent = chrome)
#> [...clipped...]

session$auto_events_enable_args(
  "Fetch",
  patterns = list(
    list(urlPattern = "*")
  ),
  handleAuthRequests = TRUE
)
# note that we don't communicate with Chrome yet...

session$Fetch$requestPaused(
  callback_ = function(x) session$Fetch$continueRequest(requestId = x$requestId)
)
#> Callbacks for Fetch++: 1
#> Enabling events for Fetch
#> SEND {"method":"Fetch.enable","params":{"patterns":[{"urlPattern":"*"}],"handleAuthRequests":true},"id":6,"sessionId":"A870CF547F3D2D630222AD5C31863233"}
#> RECV {"id":6,"result":{},"sessionId":"A870CF547F3D2D630222AD5C31863233"}
```

Note that the `Fetch.enable` has the params from `auto_events_enable_args`.