### PR TITLE
fix: `deviceScaleFactor = 0` disables the metric override

### DIFF
--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -271,14 +271,15 @@ ChromoteSession <- R6Class(
     get_viewport_size = function(wait_ = TRUE) {
       check_bool(wait_)
 
-      p <- self$Runtime$evaluate(
-        "(() => ({width: window.innerWidth, height: window.innerHeight }))()",
-        returnByValue = TRUE,
-        wait_ = FALSE
-      )$then(function(value) {
+      p <- self$Page$getLayoutMetrics(wait_ = FALSE)$then(function(value) {
         list(
-          width = value$result$value$width,
-          height = value$result$value$height,
+          width = value$cssVisualViewport$clientWidth,
+          height = value$cssVisualViewport$clientHeight
+        )
+      })$then(function(value) {
+        list(
+          width = value$width,
+          height = value$height,
           zoom = private$pixel_ratio %||% 0,
           mobile = private$is_mobile
         )

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -785,8 +785,20 @@ ChromoteSession <- R6Class(
     init_promise_ = NULL,
 
     # Updated when `Emulation.setDeviceMetricsOverride` is called
-    pixel_ratio = NULL,
     is_mobile = NULL,
+    pixel_ratio = NULL,
+
+    get_pixel_ratio = function() {
+      if (!is.null(private$pixel_ratio)) {
+        promise_resolve(private$pixel_ratio)
+      } else {
+        self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)$then(
+          function(value) {
+            (private$pixel_ratio <- value$result$value)
+          }
+        )
+      }
+    },
 
     register_event_listener = function(event, callback = NULL, timeout = NULL) {
       self$check_active()

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -340,10 +340,10 @@ ChromoteSession <- R6Class(
           wait_ = FALSE
         )
       })$then(function(value) {
-        invisible(prev_bounds)
+        prev_bounds
       })
 
-      if (wait_) self$wait_for(p) else p
+      if (wait_) invisible(self$wait_for(p)) else p
     },
 
     #' @description Take a PNG screenshot

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -279,7 +279,7 @@ ChromoteSession <- R6Class(
         list(
           width = value$result$value$width,
           height = value$result$value$height,
-          zoom = private$pixel_ratio,
+          zoom = private$pixel_ratio %||% 0,
           mobile = private$is_mobile
         )
       })
@@ -335,7 +335,7 @@ ChromoteSession <- R6Class(
         self$Emulation$setDeviceMetricsOverride(
           width = width,
           height = height,
-          deviceScaleFactor = zoom %||% private$pixel_ratio,
+          deviceScaleFactor = zoom %||% private$pixel_ratio %||% 0,
           mobile = mobile %||% private$is_mobile %||% FALSE,
           wait_ = FALSE
         )

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -132,9 +132,7 @@ ChromoteSession <- R6Class(
 
       # Find pixelRatio for screenshots
       p <- p$then(function(value) {
-        self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)
-      })$then(function(value) {
-        private$pixel_ratio <- value$result$value
+        private$get_pixel_ratio()
       })
 
       if (is.null(targetId)) {

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -127,7 +127,9 @@ gen_command_body <- function(method_name, params) {
   track_device_override_mobile <-
     if (identical(method_name, "Emulation.setDeviceMetricsOverride")) {
       expr({
-        private$pixel_ratio <- !!sym("deviceScaleFactor")
+        private$pixel_ratio <- if (!!sym("deviceScaleFactor") > 0) {
+          !!sym("deviceScaleFactor")
+        }
         private$is_mobile <- !!sym("mobile")
       })
     } else {

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -127,8 +127,10 @@ gen_command_body <- function(method_name, params) {
   track_device_override_mobile <-
     if (identical(method_name, "Emulation.setDeviceMetricsOverride")) {
       expr({
-        private$pixel_ratio <- if (!!sym("deviceScaleFactor") > 0) {
-          !!sym("deviceScaleFactor")
+        if (!!sym("deviceScaleFactor") > 0) {
+          private$pixel_ratio <- !!sym("deviceScaleFactor")
+        } else {
+          private$pixel_ratio <- NULL
         }
         private$is_mobile <- !!sym("mobile")
       })

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -76,14 +76,11 @@ chromote_session_screenshot <- function(
   )$then(function(value) {
     # Get device pixel ratio if unknown
     if (!is.null(pixel_ratio)) {
-      return(promises::promise_resolve(NULL))
+      return(NULL)
     }
-    self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)
-  })$then(function(value) {
-    if (is.null(value)) {
-      return(promises::promise_resolve(NULL))
-    }
-    pixel_ratio <<- value$result$value
+    self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)$then(function(value)
+       pixel_ratio <<- value$result$value
+    )
   })$then(function(value) {
     # Get overall height and width of the <html> root node
     self$DOM$getDocument(wait_ = FALSE)

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -78,8 +78,8 @@ chromote_session_screenshot <- function(
     if (!is.null(pixel_ratio)) {
       return(NULL)
     }
-    self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)$then(function(value)
-       pixel_ratio <<- value$result$value
+    self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)$then(
+      function(value) pixel_ratio <<- value$result$value
     )
   })$then(function(value) {
     # Get overall height and width of the <html> root node

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -67,7 +67,7 @@ chromote_session_screenshot <- function(
   overall_width <- NULL
   overall_height <- NULL
   root_node_id <- NULL
-  pixel_ratio <- private$pixel_ratio
+  pixel_ratio <- NULL
 
   # Setup stuff for both selector and cliprect code paths.
   p <- self$Emulation$setScrollbarsHidden(
@@ -75,12 +75,7 @@ chromote_session_screenshot <- function(
     wait_ = FALSE
   )$then(function(value) {
     # Get device pixel ratio if unknown
-    if (!is.null(pixel_ratio)) {
-      return(NULL)
-    }
-    self$Runtime$evaluate("window.devicePixelRatio", wait_ = FALSE)$then(
-      function(value) pixel_ratio <<- value$result$value
-    )
+    private$get_pixel_ratio()$then(function(value) pixel_ratio <<- value)
   })$then(function(value) {
     # Get overall height and width of the <html> root node
     self$DOM$getDocument(wait_ = FALSE)

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -112,7 +112,7 @@ chromote_session_screenshot <- function(
         y = ymin,
         width = xmax - xmin,
         height = ymax - ymin,
-        scale = scale / private$pixel_ratio
+        scale = scale / (private$pixel_ratio %||% 1)
       )
       screenshot_args$wait_ <- FALSE
 
@@ -128,7 +128,7 @@ chromote_session_screenshot <- function(
         y = cliprect[[2]],
         width = cliprect[[3]],
         height = cliprect[[4]],
-        scale = scale / private$pixel_ratio
+        scale = scale / (private$pixel_ratio %||% 1)
       )
       screenshot_args$wait_ <- FALSE
 

--- a/tests/testthat/_snaps/chromote_session.md
+++ b/tests/testthat/_snaps/chromote_session.md
@@ -1,33 +1,17 @@
 # ChromoteSession auto_events_enable_args errors
 
     Code
-      ChromoteSession$new(auto_events_enable_args = NULL)
+      chromote_session$auto_events_enable_args("Browser", no_enable = TRUE)
     Condition
-      Error in `initialize()`:
-      ! `auto_events_enable_args` must be a named list of domains and associated arguments for the `enable` command.
-
----
-
-    Code
-      ChromoteSession$new(auto_events_enable_args = list("also bad"))
-    Condition
-      Error in `initialize()`:
-      ! `auto_events_enable_args` must be a named list of domains and associated arguments for the `enable` command.
-
----
-
-    Code
-      ChromoteSession$new(auto_events_enable_args = list(Browser = list(no_enable = TRUE)))
-    Condition
-      Error in `self$auto_events_enable_args()`:
+      Error in `chromote_session$auto_events_enable_args()`:
       ! Browser does not have an enable method.
 
 ---
 
     Code
-      ChromoteSession$new(auto_events_enable_args = list(Animation = list(bad = TRUE)))
+      chromote_session$auto_events_enable_args("Animation", bad = TRUE)
     Condition
-      Error in `self$auto_events_enable_args()`:
+      Error in `chromote_session$auto_events_enable_args()`:
       ! Animation.enable does not have argument: `bad`.
       i Available arguments: `callback_`, `error_`, and `timeout_`
 

--- a/tests/testthat/test-chromote_session.R
+++ b/tests/testthat/test-chromote_session.R
@@ -71,7 +71,10 @@ test_that("ChromoteSession inherits `auto_events_enable_args` from parent", {
     Network = list(maxTotalBufferSize = 1024)
   )
 
-  parent <- Chromote$new(auto_events_enable_args = args)
+  parent <- Chromote$new()
+  for (domain in names(args)) {
+    parent$auto_events_enable_args(domain, !!!args[[domain]])
+  }
   page <- ChromoteSession$new(parent = parent)
 
   expect_equal(
@@ -108,11 +111,15 @@ test_that("ChromoteSession$new(auto_events_enable_args)", {
   args_parent <- list(DOM = list(includeWhitespace = FALSE))
   args_page <- list(DOM = list(includeWhitespace = TRUE))
 
-  parent <- Chromote$new(auto_events_enable_args = args_parent)
-  page <- ChromoteSession$new(
-    parent = parent,
-    auto_events_enable_args = args_page
-  )
+  parent <- Chromote$new()
+  for (domain in names(args_parent)) {
+    parent$auto_events_enable_args(domain, !!!args_parent[[domain]])
+  }
+
+  page <- ChromoteSession$new(parent = parent)
+  for (domain in names(args_page)) {
+    page$auto_events_enable_args(domain, !!!args_page[[domain]])
+  }
 
   expect_equal(
     page$auto_events_enable_args("DOM"),
@@ -135,34 +142,20 @@ test_that("ChromoteSession$new(auto_events_enable_args)", {
 test_that("ChromoteSession auto_events_enable_args errors", {
   skip_if_no_chromote()
 
+  chromote_session <- ChromoteSession$new()
+
   expect_snapshot(
-    ChromoteSession$new(auto_events_enable_args = NULL),
+    chromote_session$auto_events_enable_args("Browser", no_enable = TRUE),
     error = TRUE
   )
 
   expect_snapshot(
-    ChromoteSession$new(auto_events_enable_args = list("also bad")),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ChromoteSession$new(
-      auto_events_enable_args = list(Browser = list(no_enable = TRUE))
-    ),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ChromoteSession$new(
-      auto_events_enable_args = list(Animation = list(bad = TRUE))
-    ),
+    chromote_session$auto_events_enable_args("Animation", bad = TRUE),
     error = TRUE
   )
 
   expect_warning(
-    ChromoteSession$new(
-      auto_events_enable_args = list(Animation = list(wait_ = TRUE))
-    )
+    chromote_session$auto_events_enable_args("Animation", wait_ = TRUE)
   )
 })
 

--- a/tests/testthat/test-chromote_session.R
+++ b/tests/testthat/test-chromote_session.R
@@ -62,3 +62,42 @@ test_that("ChromoteSession gets and sets viewport size", {
     )
   )
 })
+
+test_that("ChromoteSession with deviceScaleFactor = 0", {
+  skip_if_no_chromote()
+  skip_if_offline()
+
+  page <- ChromoteSession$new(width = 400, height = 800, mobile = TRUE)
+  # viewport requires an active page
+  page$Page$navigate("https://example.com")
+  withr::defer(page$close())
+
+  init_size <- list(
+    width = 400,
+    height = 800,
+    zoom = page$.__enclos_env__$private$pixel_ratio,
+    mobile = TRUE
+  )
+
+  expect_equal(
+    page$get_viewport_size(),
+    init_size
+  )
+
+  expect_equal(
+    page$set_viewport_size(500, 900, zoom = 0, mobile = FALSE),
+    init_size # returned invisibly
+  )
+
+  expect_null(page$.__enclos_env__$private$pixel_ratio)
+
+  expect_equal(
+    page$get_viewport_size(),
+    list(
+      width = 500,
+      height = 900,
+      zoom = 0,
+      mobile = FALSE
+    )
+  )
+})


### PR DESCRIPTION
Fixes rstudio/shinytest2#404

In rstudio/shinytest2#350, we went from using `deviceScaleFactor = 1` before screenshots to using `deviceScaleFactor = 0` in the `Emulation.setDeviceMetricsOverride` command. As pointed out there, the [CDP docs explain](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride) that this is equivalent to disabling deivce scaling.

The issue rstudio/shinytest2#350 resolved was a problem that was flagged for us on CRAN that was difficult to reproduce. IIRC, we eventually realized that we were getting different screenshot sizes on Mac when the Chrome browser window was being displayed on a Retina display vs a monitor (and by association, the failing manual CRAN tests were happening on a laptop display).

That said, playwright defaults to `deviceScaleFactor = 1`: https://github.com/microsoft/playwright/blob/3b9515e7efa07230684bef9704c601f509f8ad72/packages/playwright-core/src/server/chromium/crPage.ts#L964

Anyway, for consistently sized screenshots, we may end up in a situation where we need to query `window.devicePixelRatio` to find the current value (because `deviceScaleFactor` was set to `0`).

In retrospect, the real issue behind rstudio/shinytest2#350 was that we were calling `Emulation.setDeviceMetricsOverride` and setting `deviceScaleFactor = 1`, but internally the screenshot method was still using `pixel_ratio = 2` because we weren't tracking changes to `pixel_ratio`. So using `deviceScaleFactor = 0` in shinytest2 was equivalent to not changing the pixel ratio.

We could consider not tracking `pixel_ratio` at all, but our current approach does save us a round trip call or two to the browser whenever we change the viewport size.