### PR TITLE
feat: Improve `$is_alive()`, `$close()` for local and remote processes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
-Config/testthat/parallel: TRUE
+Config/testthat/parallel: FALSE
 Config/testthat/start-first: chromote_session
 Encoding: UTF-8
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 * The `$view()` method of a `ChromoteSession` will now detect when `chrome-headless-shell` is being used and will use the system browser (via `utils::browseURL()`) rather than the Chrome instance attached to chromote. (#214)
 
+* `Chromote` and `ChromoteSession` once again corrrectly handles connections to remote Chrome browsers via `ChromeRemote`. Calling `$close()` on a `Chromote` object connected to a remote browser no longer attempts to close the browser, and will now simply close the websocket connection to the browser. For local process, the `Chromote$close()` gains a `wait` argument that sets the number of seconds to wait for Chrome to gracefully shut down before chromote closes the process. (#212)
+
 # chromote 0.4.0
 
 * Chrome v132 and later no longer support [old headless mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome). As such, `chromote` no longer defaults to using `--headless=old` and now uses `--headless` when running Chrome. You can still use the `chromote.headless` option or `CHROMOTE_HEADLESS` environment variable to configure the `--headless` flag if you're using an older version of Chrome. (#187)

--- a/R/browser.R
+++ b/R/browser.R
@@ -46,19 +46,26 @@ Browser <- R6Class(
         check_number_whole(wait, min = 0)
       }
 
-      message("Sending SIGTERM to PID ", private$process$get_pid())
+      log <- function(...) {
+        message(
+          strftime(Sys.time(), "[%F %T] "),
+          ...
+        )
+      }
+
+      log("Sending SIGTERM to PID ", private$process$get_pid())
       private$process$signal(tools::SIGTERM)
 
       if (!isFALSE(wait)) {
         tryCatch(
           {
-            message("Waiting for PID ", private$process$get_pid(), " to exit")
+            log("Waiting for PID ", private$process$get_pid(), " to exit")
             private$process$wait(timeout = wait)
-            message("Process exited cleanly")
+            log("Process exited cleanly")
           },
           error = function(err) {
             # Still alive after 10 seconds...
-            message("Process did not exit cleanly, now we're killing it")
+            log("Process did not exit cleanly, now we're killing it")
             try(private$process$kill(), silent = TRUE)
           }
         )

--- a/R/browser.R
+++ b/R/browser.R
@@ -34,6 +34,9 @@ Browser <- R6Class(
     get_port = function() private$port,
 
     #' @description Close the browser
+    #' @param wait If an integer, waits a number of seconds for the process to
+    #'   exit, killing the process if it takes longer than `wait` seconds to
+    #'   close. Use `wait = TRUE` to wait for 10 seconds.
     close = function(wait = FALSE) {
       if (!self$is_local()) return(invisible())
       if (!private$process$is_alive()) return(invisible())
@@ -44,7 +47,7 @@ Browser <- R6Class(
         wait <- 10
       }
       if (!isFALSE(wait)) {
-        check_number_whole(wait, min = -1)
+        check_number_whole(wait, min = 0)
         should_wait <- TRUE
       }
 
@@ -53,7 +56,7 @@ Browser <- R6Class(
       if (should_wait) {
         tryCatch(
           private$process$wait(timeout = wait),
-          error = function() {
+          error = function(err) {
             # Still alive after 10 seconds...
             private$process$kill()
           }

--- a/R/browser.R
+++ b/R/browser.R
@@ -46,14 +46,20 @@ Browser <- R6Class(
         check_number_whole(wait, min = 0)
       }
 
+      message("Sending SIGTERM to PID ", private$process$get_pid())
       private$process$signal(tools::SIGTERM)
 
       if (!isFALSE(wait)) {
         tryCatch(
-          private$process$wait(timeout = wait),
+          {
+            message("Waiting for PID ", private$process$get_pid(), " to exit")
+            private$process$wait(timeout = wait)
+            message("Process exited cleanly")
+          },
           error = function(err) {
             # Still alive after 10 seconds...
-            private$process$kill()
+            message("Process did not exit cleanly, now we're killing it")
+            try(private$process$kill(), silent = TRUE)
           }
         )
       }

--- a/R/browser.R
+++ b/R/browser.R
@@ -46,32 +46,18 @@ Browser <- R6Class(
         check_number_whole(wait, min = 0)
       }
 
-      log <- function(...) {
-        message(
-          strftime(Sys.time(), "[%F %T] "),
-          private$process$get_pid(),
-          " | ",
-          ...
-        )
-      }
-
-      log("Sending SIGTERM")
       private$process$signal(tools::SIGTERM)
 
       if (!isFALSE(wait)) {
         tryCatch(
           {
-            log("Waiting for process to exit")
             private$process$wait(timeout = wait * 1000)
             if (private$process$is_alive()) {
-              log("browser process is STILL alive")
-              stop("shut it down")
+              stop("shut it down") # ignored, used to escalate
             }
-            log("Process exited cleanly")
           },
           error = function(err) {
-            # Still alive after 10 seconds...
-            log("Process did not exit cleanly, now we're killing it")
+            # Still alive after wait...
             try(private$process$kill(), silent = TRUE)
           }
         )

--- a/R/browser.R
+++ b/R/browser.R
@@ -41,19 +41,14 @@ Browser <- R6Class(
       if (!self$is_local()) return(invisible())
       if (!private$process$is_alive()) return(invisible())
 
-      should_wait <- FALSE
-      if (isTRUE(wait)) {
-        should_wait <- TRUE
-        wait <- 10
-      }
       if (!isFALSE(wait)) {
+        if (isTRUE(wait)) wait <- 10
         check_number_whole(wait, min = 0)
-        should_wait <- TRUE
       }
 
       private$process$signal(tools::SIGTERM)
 
-      if (should_wait) {
+      if (!isFALSE(wait)) {
         tryCatch(
           private$process$wait(timeout = wait),
           error = function(err) {

--- a/R/browser.R
+++ b/R/browser.R
@@ -63,6 +63,10 @@ Browser <- R6Class(
           {
             log("Waiting for process to exit")
             private$process$wait(timeout = wait * 1000)
+            if (private$process$is_alive()) {
+              log("browser process is STILL alive")
+              stop("shut it down")
+            }
             log("Process exited cleanly")
           },
           error = function(err) {

--- a/R/browser.R
+++ b/R/browser.R
@@ -49,18 +49,20 @@ Browser <- R6Class(
       log <- function(...) {
         message(
           strftime(Sys.time(), "[%F %T] "),
+          private$process$get_pid(),
+          " | ",
           ...
         )
       }
 
-      log("Sending SIGTERM to PID ", private$process$get_pid())
+      log("Sending SIGTERM")
       private$process$signal(tools::SIGTERM)
 
       if (!isFALSE(wait)) {
         tryCatch(
           {
-            log("Waiting for PID ", private$process$get_pid(), " to exit")
-            private$process$wait(timeout = wait)
+            log("Waiting for process to exit")
+            private$process$wait(timeout = wait * 1000)
             log("Process exited cleanly")
           },
           error = function(err) {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -509,6 +509,20 @@ ChromeRemote <- R6Class(
     initialize = function(host, port) {
       private$host <- host
       private$port <- port
+    },
+
+    #' @description Is the remote service alive?
+    is_alive = function() {
+      url <- sprintf("https://%s:%s/json/version", private$host, private$port)
+
+      tryCatch(
+        {
+          # If we can read info from the remote host, then it's alive
+          fromJSON(url)
+          TRUE
+        },
+        error = function(err) FALSE
+      )
     }
   )
 )

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -69,6 +69,14 @@ ChromeRemote <- R6Class(
         },
         error = function(err) FALSE
       )
+    },
+
+    #' @description chromote does not manage remote processes, so closing a
+    #'   remote Chrome browser does nothing. You can send a `Browser$close()`
+    #'   command if this is really something you want to do.
+    close = function() {
+      # chromote didn't start this process, so we won't kill it or close it.
+      invisible(TRUE)
     }
   )
 )

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -38,6 +38,41 @@ Chrome <- R6Class(
   )
 )
 
+#' Remote Chrome process
+#'
+#' @description
+#' Remote Chrome process
+#'
+#' @export
+ChromeRemote <- R6Class(
+  "ChromeRemote",
+  inherit = Browser,
+  public = list(
+    #' @description Create a new ChromeRemote object.
+    #' @param host A string that is a valid IPv4 or IPv6 address. `"0.0.0.0"`
+    #' represents all IPv4 addresses and `"::/0"` represents all IPv6 addresses.
+    #' @param port A number or integer that indicates the server port.
+    initialize = function(host, port) {
+      private$host <- host
+      private$port <- port
+    },
+
+    #' @description Is the remote service alive?
+    is_alive = function() {
+      url <- sprintf("https://%s:%s/json/version", private$host, private$port)
+
+      tryCatch(
+        {
+          # If we can read info from the remote host, then it's alive
+          fromJSON(url)
+          TRUE
+        },
+        error = function(err) FALSE
+      )
+    }
+  )
+)
+
 #' Find path to Chrome or Chromium browser
 #'
 #' @description
@@ -491,38 +526,3 @@ launch_chrome_impl <- function(path, args, port) {
     port = port
   )
 }
-
-#' Remote Chrome process
-#'
-#' @description
-#' Remote Chrome process
-#'
-#' @export
-ChromeRemote <- R6Class(
-  "ChromeRemote",
-  inherit = Browser,
-  public = list(
-    #' @description Create a new ChromeRemote object.
-    #' @param host A string that is a valid IPv4 or IPv6 address. `"0.0.0.0"`
-    #' represents all IPv4 addresses and `"::/0"` represents all IPv6 addresses.
-    #' @param port A number or integer that indicates the server port.
-    initialize = function(host, port) {
-      private$host <- host
-      private$port <- port
-    },
-
-    #' @description Is the remote service alive?
-    is_alive = function() {
-      url <- sprintf("https://%s:%s/json/version", private$host, private$port)
-
-      tryCatch(
-        {
-          # If we can read info from the remote host, then it's alive
-          fromJSON(url)
-          TRUE
-        },
-        error = function(err) FALSE
-      )
-    }
-  )
-)

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -59,7 +59,7 @@ ChromeRemote <- R6Class(
 
     #' @description Is the remote service alive?
     is_alive = function() {
-      url <- sprintf("https://%s:%s/json/version", private$host, private$port)
+      url <- sprintf("http://%s:%s/json/version", private$host, private$port)
 
       tryCatch(
         {

--- a/R/chrome.R
+++ b/R/chrome.R
@@ -64,7 +64,7 @@ ChromeRemote <- R6Class(
       tryCatch(
         {
           # If we can read info from the remote host, then it's alive
-          fromJSON(url)
+          suppressWarnings(fromJSON(url))
           TRUE
         },
         error = function(err) FALSE

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -441,12 +441,16 @@ Chromote <- R6Class(
         # or close it forcefully if it takes too long
         tryCatch(
           {
-            message("waiting for browser process to shut down")
+            pid <- private$browser$get_process()$get_pid()
+            message("waiting for browser process ", pid, " to shut down")
             private$browser$get_process()$wait(timeout = wait)
-            message("browser process exited")
+            message("browser process ", pid, " exited")
+            if (private$browser$get_process()$is_alive()) {
+              message("browser process ", pid, " is still alive >:(")
+            }
           },
           error = function(err) {
-            message("timed out waiting for browser to close, escalating")
+            message("timed out waiting for browser ", pid, " to close, escalating") # fmt: skip
             private$browser$close(wait = 1)
           }
         )

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -443,9 +443,10 @@ Chromote <- R6Class(
         )
       }
 
-      # close the browser nicely
+      # close the browser nicely, immediately close websocket
       log("Sending `Browser.close` message")
       self$Browser$close()
+      try(private$ws$close(), silent = TRUE)
 
       if (!isFALSE(wait)) {
         # or close it forcefully if it takes too long
@@ -464,10 +465,6 @@ Chromote <- R6Class(
             private$browser$close(wait = 1)
           }
         )
-      }
-
-      if (private$ws$readyState() %in% c(0L, 1L)) {
-        try(private$ws$close(), silent = TRUE)
       }
 
       invisible()

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -447,6 +447,7 @@ Chromote <- R6Class(
             message("browser process ", pid, " exited")
             if (private$browser$get_process()$is_alive()) {
               message("browser process ", pid, " is still alive >:(")
+              stop("shut it down")
             }
           },
           error = function(err) {

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -447,7 +447,9 @@ Chromote <- R6Class(
         )
       }
 
-      (private$ws$readyState() %in% c(0L, 1L)) || private$ws$close()
+      if (private$ws$readyState() %in% c(0L, 1L)) {
+        try(private$ws$close(), silent = TRUE)
+      }
 
       invisible()
     },

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -445,7 +445,7 @@ Chromote <- R6Class(
 
       # close the browser nicely, immediately close websocket
       log("Sending `Browser.close` message")
-      self$Browser$close()
+      self$Browser$close(wait_ = FALSE)
       try(private$ws$close(), silent = TRUE)
 
       if (!isFALSE(wait)) {
@@ -454,7 +454,6 @@ Chromote <- R6Class(
           {
             log("waiting for browser process to shut down")
             private$browser$get_process()$wait(timeout = wait * 1000)
-            log("$wait() exited")
             if (private$browser$get_process()$is_alive()) {
               log("browser process is still alive >:(")
               stop("shut it down")
@@ -463,6 +462,7 @@ Chromote <- R6Class(
           },
           error = function(err) {
             log("timed out waiting for browser to close, escalating") # fmt: skip
+            try(private$ws$close(), silent = TRUE)
             private$browser$close(wait = 1)
           }
         )

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -459,6 +459,7 @@ Chromote <- R6Class(
               log("browser process is still alive >:(")
               stop("shut it down")
             }
+            log("browser process exited cleanly")
           },
           error = function(err) {
             log("timed out waiting for browser to close, escalating") # fmt: skip

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -434,17 +434,7 @@ Chromote <- R6Class(
         return(invisible())
       }
 
-      log <- function(...) {
-        message(
-          strftime(Sys.time(), "[%F %T] "),
-          private$browser$get_process()$get_pid(),
-          " | ",
-          ...
-        )
-      }
-
       # close the browser nicely, immediately close websocket
-      log("Sending `Browser.close` message")
       self$Browser$close(wait_ = FALSE)
       try(private$ws$close(), silent = TRUE)
 
@@ -452,16 +442,12 @@ Chromote <- R6Class(
         # or close it forcefully if it takes too long
         tryCatch(
           {
-            log("waiting for browser process to shut down")
             private$browser$get_process()$wait(timeout = wait * 1000)
             if (private$browser$get_process()$is_alive()) {
-              log("browser process is still alive >:(")
-              stop("shut it down")
+              stop("shut it down") # ignored, used to escalate
             }
-            log("browser process exited cleanly")
           },
           error = function(err) {
-            log("timed out waiting for browser to close, escalating") # fmt: skip
             try(private$ws$close(), silent = TRUE)
             private$browser$close(wait = 1)
           }

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -440,8 +440,13 @@ Chromote <- R6Class(
       if (!isFALSE(wait)) {
         # or close it forcefully if it takes too long
         tryCatch(
-          private$browser$get_process()$wait(timeout = wait),
+          {
+            message("waiting for browser process to shut down")
+            private$browser$get_process()$wait(timeout = wait)
+            message("browser process exited")
+          },
           error = function(err) {
+            message("timed out waiting for browser to close, escalating")
             private$browser$close(wait = 1)
           }
         )

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -436,6 +436,12 @@ Chromote <- R6Class(
     stop = function() {
       private$ws$close()
       private$browser$close()
+      private$browser$get_process()$wait(timeout = 10)
+
+      if (private$browser$is_alive()) {
+        # Still alive after 10 seconds...
+        private$browser$get_process()$kill()
+      }
 
       invisible()
     },

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -435,13 +435,7 @@ Chromote <- R6Class(
     #' @description Forcefully stop the [`Browser`] process
     stop = function() {
       private$ws$close()
-      private$browser$close()
-      private$browser$get_process()$wait(timeout = 10)
-
-      if (private$browser$is_alive()) {
-        # Still alive after 10 seconds...
-        private$browser$get_process()$kill()
-      }
+      private$browser$close(wait = TRUE)
 
       invisible()
     },

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -434,31 +434,33 @@ Chromote <- R6Class(
         return(invisible())
       }
 
-      # close the browser nicely
-      self$Browser$close()
-
       log <- function(...) {
         message(
           strftime(Sys.time(), "[%F %T] "),
+          private$browser$get_process()$get_pid(),
+          " | ",
           ...
         )
       }
+
+      # close the browser nicely
+      log("Sending `Browser.close` message")
+      self$Browser$close()
 
       if (!isFALSE(wait)) {
         # or close it forcefully if it takes too long
         tryCatch(
           {
-            pid <- private$browser$get_process()$get_pid()
-            log("waiting for browser process ", pid, " to shut down")
-            private$browser$get_process()$wait(timeout = wait)
-            log("browser process ", pid, " exited")
+            log("waiting for browser process to shut down")
+            private$browser$get_process()$wait(timeout = wait * 1000)
+            log("$wait() exited")
             if (private$browser$get_process()$is_alive()) {
-              log("browser process ", pid, " is still alive >:(")
+              log("browser process is still alive >:(")
               stop("shut it down")
             }
           },
           error = function(err) {
-            log("timed out waiting for browser ", pid, " to close, escalating") # fmt: skip
+            log("timed out waiting for browser to close, escalating") # fmt: skip
             private$browser$close(wait = 1)
           }
         )

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -437,7 +437,7 @@ Chromote <- R6Class(
       # close the browser nicely
       self$Browser$close()
 
-      if (!isFALSE(wait) && wait > 0) {
+      if (!isFALSE(wait)) {
         # or close it forcefully if it takes too long
         tryCatch(
           private$browser$get_process()$wait(timeout = wait),

--- a/R/chromote.R
+++ b/R/chromote.R
@@ -437,21 +437,28 @@ Chromote <- R6Class(
       # close the browser nicely
       self$Browser$close()
 
+      log <- function(...) {
+        message(
+          strftime(Sys.time(), "[%F %T] "),
+          ...
+        )
+      }
+
       if (!isFALSE(wait)) {
         # or close it forcefully if it takes too long
         tryCatch(
           {
             pid <- private$browser$get_process()$get_pid()
-            message("waiting for browser process ", pid, " to shut down")
+            log("waiting for browser process ", pid, " to shut down")
             private$browser$get_process()$wait(timeout = wait)
-            message("browser process ", pid, " exited")
+            log("browser process ", pid, " exited")
             if (private$browser$get_process()$is_alive()) {
-              message("browser process ", pid, " is still alive >:(")
+              log("browser process ", pid, " is still alive >:(")
               stop("shut it down")
             }
           },
           error = function(err) {
-            message("timed out waiting for browser ", pid, " to close, escalating") # fmt: skip
+            log("timed out waiting for browser ", pid, " to close, escalating") # fmt: skip
             private$browser$close(wait = 1)
           }
         )

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -792,11 +792,20 @@ ChromoteSession <- R6Class(
         cat_line("<ChromoteSession> (", state, ")")
         if (self$is_active()) cat_line("  Session ID: ", self$get_session_id())
         if (private$target_is_active)
-          cat_line("  Target ID:  ", self$get_target_id())
-        cat_line(
-          "  Parent PID: ",
-          self$parent$get_browser()$get_process()$get_pid()
-        )
+          cat_line("   Target ID: ", self$get_target_id())
+
+        browser <- self$parent$get_browser()
+        if (browser$is_local()) {
+          cat_line(
+            "  Parent PID: ",
+            self$parent$get_browser()$get_process()$get_pid()
+          )
+        } else {
+          cat_line(
+            " Remote Host: ",
+            sprintf("http://%s:%s", browser$get_host(), browser$get_port())
+          )
+        }
       }
       invisible(self)
     },

--- a/R/manage.R
+++ b/R/manage.R
@@ -140,7 +140,7 @@ local_chromote_chrome <- function(path, ..., .local_envir = parent.frame()) {
     {
       if (has_default_chromote_object()) {
         current <- default_chromote_object()
-        current$stop()
+        current$close()
       }
 
       if (is.null(old_default_chromote_object)) {

--- a/R/manage.R
+++ b/R/manage.R
@@ -154,9 +154,11 @@ local_chromote_chrome <- function(path, ..., .local_envir = parent.frame()) {
     envir = .local_envir
   )
 
-  # Unset current default so that next ChromoteSession uses a new Chromote obj,
-  # but `set_default_chromote_object()` requires a chromote obj that we don't
-  # want to create yet.
+  # We always create a *new* Chromote process within `local_chromote_chrome()`
+  # that we completely clean up when the exit handlers run. We do this by
+  # unsetting the current chromote default so that next ChromoteSession uses a
+  # new Chromote obj, side-stepping `set_default_chromote_object()` because that
+  # requires a chromote obj that we don't want to create yet.
   globals$default_chromote <- NULL
 
   withr::local_envvar(

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -75,7 +75,9 @@ chromote_session_screenshot <- function(
     wait_ = FALSE
   )$then(function(value) {
     # Get device pixel ratio if unknown
-    private$get_pixel_ratio()$then(function(value) pixel_ratio <<- value)
+    private$get_pixel_ratio()
+  })$then(function(value) {
+    pixel_ratio <<- value
   })$then(function(value) {
     # Get overall height and width of the <html> root node
     self$DOM$getDocument(wait_ = FALSE)

--- a/man/Browser.Rd
+++ b/man/Browser.Rd
@@ -82,9 +82,18 @@ Browser port
 \subsection{Method \code{close()}}{
 Close the browser
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Browser$close()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Browser$close(wait = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{wait}}{If an integer, waits a number of seconds for the process to
+exit, killing the process if it takes longer than \code{wait} seconds to
+close. Use \code{wait = TRUE} to wait for 10 seconds.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Browser-clone"></a>}}

--- a/man/ChromeRemote.Rd
+++ b/man/ChromeRemote.Rd
@@ -14,13 +14,13 @@ Remote Chrome process
 \itemize{
 \item \href{#method-ChromeRemote-new}{\code{ChromeRemote$new()}}
 \item \href{#method-ChromeRemote-is_alive}{\code{ChromeRemote$is_alive()}}
+\item \href{#method-ChromeRemote-close}{\code{ChromeRemote$close()}}
 \item \href{#method-ChromeRemote-clone}{\code{ChromeRemote$clone()}}
 }
 }
 \if{html}{\out{
 <details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="close"><a href='../../chromote/html/Browser.html#method-Browser-close'><code>chromote::Browser$close()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_host"><a href='../../chromote/html/Browser.html#method-Browser-get_host'><code>chromote::Browser$get_host()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_port"><a href='../../chromote/html/Browser.html#method-Browser-get_port'><code>chromote::Browser$get_port()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_process"><a href='../../chromote/html/Browser.html#method-Browser-get_process'><code>chromote::Browser$get_process()</code></a></span></li>
@@ -55,6 +55,18 @@ represents all IPv4 addresses and \code{"::/0"} represents all IPv6 addresses.}
 Is the remote service alive?
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ChromeRemote$is_alive()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromeRemote-close"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromeRemote-close}{}}}
+\subsection{Method \code{close()}}{
+chromote does not manage remote processes, so closing a
+remote Chrome browser does nothing. You can send a \code{Browser$close()}
+command if this is really something you want to do.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromeRemote$close()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/ChromeRemote.Rd
+++ b/man/ChromeRemote.Rd
@@ -13,17 +13,17 @@ Remote Chrome process
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-ChromeRemote-new}{\code{ChromeRemote$new()}}
+\item \href{#method-ChromeRemote-is_alive}{\code{ChromeRemote$is_alive()}}
 \item \href{#method-ChromeRemote-clone}{\code{ChromeRemote$clone()}}
 }
 }
 \if{html}{\out{
-<details><summary>Inherited methods</summary>
+<details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="close"><a href='../../chromote/html/Browser.html#method-Browser-close'><code>chromote::Browser$close()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_host"><a href='../../chromote/html/Browser.html#method-Browser-get_host'><code>chromote::Browser$get_host()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_port"><a href='../../chromote/html/Browser.html#method-Browser-get_port'><code>chromote::Browser$get_port()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="get_process"><a href='../../chromote/html/Browser.html#method-Browser-get_process'><code>chromote::Browser$get_process()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_alive"><a href='../../chromote/html/Browser.html#method-Browser-is_alive'><code>chromote::Browser$is_alive()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="chromote" data-topic="Browser" data-id="is_local"><a href='../../chromote/html/Browser.html#method-Browser-is_local'><code>chromote::Browser$is_local()</code></a></span></li>
 </ul>
 </details>
@@ -47,6 +47,16 @@ represents all IPv4 addresses and \code{"::/0"} represents all IPv6 addresses.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromeRemote-is_alive"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromeRemote-is_alive}{}}}
+\subsection{Method \code{is_alive()}}{
+Is the remote service alive?
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromeRemote$is_alive()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromeRemote-clone"></a>}}

--- a/man/Chromote.Rd
+++ b/man/Chromote.Rd
@@ -56,7 +56,6 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-Chromote-check_active}{\code{Chromote$check_active()}}
 \item \href{#method-Chromote-get_browser}{\code{Chromote$get_browser()}}
 \item \href{#method-Chromote-close}{\code{Chromote$close()}}
-\item \href{#method-Chromote-stop}{\code{Chromote$stop()}}
 \item \href{#method-Chromote-print}{\code{Chromote$print()}}
 }
 }
@@ -411,19 +410,20 @@ Retrieve \code{\link{Browser}}` object
 \subsection{Method \code{close()}}{
 Close the \code{\link{Browser}} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$close()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chromote$close(wait = TRUE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{wait}}{If an integer, waits a number of seconds for the process to
+exit, killing the process if it takes longer than \code{wait} seconds to
+close. Use \code{wait = TRUE} to wait for 10 seconds, or \code{wait = FALSE} to
+close the connection without waiting for the process to exit. Only
+applies when Chromote is connected to a local process.}
 }
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Chromote-stop"></a>}}
-\if{latex}{\out{\hypertarget{method-Chromote-stop}{}}}
-\subsection{Method \code{stop()}}{
-Forcefully stop the \code{\link{Browser}} process
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chromote$stop()}\if{html}{\out{</div>}}
+\if{html}{\out{</div>}}
 }
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chromote-print"></a>}}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,7 +3,7 @@ library(chromote)
 
 on_cran <- !interactive() && isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
 
-if (!on_cran && !identical(Sys.getenv("CHROMOTE_CHROME"), "")) {
+if (!on_cran && identical(Sys.getenv("CHROMOTE_CHROME"), "")) {
   path <- chrome_versions_add("latest-stable", "chrome")
   Sys.setenv("CHROMOTE_CHROME" = path)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,11 @@
 library(testthat)
 library(chromote)
 
+on_cran <- !interactive() && isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
+
+if (!on_cran && !identical(Sys.getenv("CHROMOTE_CHROME"), "")) {
+  path <- chrome_versions_add("latest-stable", "chrome")
+  Sys.setenv("CHROMOTE_CHROME" = path)
+}
+
 test_check("chromote")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,11 +1,4 @@
 library(testthat)
 library(chromote)
 
-on_cran <- !interactive() && isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
-
-if (!on_cran && identical(Sys.getenv("CHROMOTE_CHROME"), "")) {
-  path <- chrome_versions_add("latest-stable", "chrome")
-  Sys.setenv("CHROMOTE_CHROME" = path)
-}
-
 test_check("chromote")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -24,10 +24,3 @@ has_chromote <- function() {
     }
   )
 }
-
-set_state_inspector(function() {
-  list(
-    options = options(),
-    envvars = Sys.getenv()
-  )
-})

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -24,3 +24,26 @@ has_chromote <- function() {
     }
   )
 }
+
+with_retries <- function(fn, max_tries = 3) {
+  retry <- function(tried = 0) {
+    tryCatch(
+      {
+        fn()
+      },
+      error = function(err) {
+        tried <- tried + 1
+        if (tried >= max_tries) {
+          rlang::abort(
+            sprintf("Failed after %s tries", tried),
+            parent = err
+          )
+        } else {
+          retry(tried)
+        }
+      }
+    )
+  }
+
+  retry()
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -26,6 +26,8 @@ has_chromote <- function() {
 }
 
 with_retries <- function(fn, max_tries = 3) {
+  trace <- trace_back()
+
   retry <- function(tried = 0) {
     tryCatch(
       {
@@ -36,7 +38,8 @@ with_retries <- function(fn, max_tries = 3) {
         if (tried >= max_tries) {
           rlang::abort(
             sprintf("Failed after %s tries", tried),
-            parent = err
+            parent = err,
+            trace = trace
           )
         } else {
           retry(tried)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -24,3 +24,10 @@ has_chromote <- function() {
     }
   )
 }
+
+set_state_inspector(function() {
+  list(
+    options = options(),
+    envvars = Sys.getenv()
+  )
+})

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,7 @@
+skip_on_cran()
+
+has_chromote_envvar <- !identical(Sys.getenv("CHROMOTE_CHROME"), "")
+
+if (!has_chromote_envvar) {
+  local_chrome_version("latest-stable", "chrome")
+}

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -16,6 +16,8 @@ expect_true_eventually <- function(expr, max_tries = 50, delay = 0.1) {
 }
 
 test_that("chrome with remote hosts", {
+  skip_if_no_chromote()
+
   res <- with_random_port(function(port) {
     args <- c(
       get_chrome_args(),

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -28,7 +28,7 @@ test_that("chrome with remote hosts", {
     list(port = port, process = p)
   })
 
-  withr::defer(res$process$kill())
+  withr::defer(res$process$is_alive() || res$process$kill())
 
   remote <- ChromeRemote$new(host = "localhost", port = res$port)
 
@@ -53,5 +53,12 @@ test_that("chrome with remote hosts", {
   expect_true_eventually(chromote$is_active())
   expect_true_eventually(tab2$is_active())
 
-  # TODO: Close the connection gracefully and test
+  tab2$close()
+  expect_false(tab$is_active())
+  tab2$parent$close()
+  expect_true_eventually(!chromote$is_active())
+  expect_true(chromote$is_alive()) # still alive, we haven't killed the process yet
+
+  res$process$kill()
+  expect_true_eventually(!chromote$is_alive())
 })

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -1,0 +1,57 @@
+expect_true_eventually <- function(expr, max_tries = 50, delay = 0.1) {
+  expr <- enquo(expr)
+
+  expect_true(
+    with_retries(
+      function() {
+        if (!eval_tidy(expr)) {
+          Sys.sleep(delay)
+          stop(expr_text(expr), " is not yet TRUE")
+        }
+        TRUE
+      },
+      max_tries = max_tries
+    )
+  )
+}
+
+test_that("chrome with remote hosts", {
+  res <- with_random_port(function(port) {
+    args <- c(
+      get_chrome_args(),
+      "--headless",
+      "--remote-debugging-address=0.0.0.0",
+      sprintf("--remote-debugging-port=%s", port)
+    )
+
+    p <- processx::process$new(find_chrome(), args)
+    list(port = port, process = p)
+  })
+
+  withr::defer(res$process$kill())
+
+  remote <- ChromeRemote$new(host = "localhost", port = res$port)
+
+  expect_true_eventually(remote$is_alive())
+  expect_true(remote$close()) # does nothing but invisibly returns TRUE
+  expect_true(remote$is_alive())
+
+  chromote <- Chromote$new(browser = remote)
+  expect_true(chromote$is_alive())
+  expect_true(chromote$is_active())
+
+  tab <- ChromoteSession$new(parent = chromote)
+  expect_true(tab$is_active())
+
+  # Close the websocket
+  chromote$.__enclos_env__$private$ws$close()
+  expect_true_eventually(!chromote$is_active())
+  expect_true_eventually(!tab$is_active())
+
+  # Reconnect
+  tab2 <- suppressMessages(tab$respawn())
+  expect_true_eventually(chromote$is_active())
+  expect_true_eventually(tab2$is_active())
+
+  # TODO: Close the connection gracefully and test
+})

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -28,7 +28,7 @@ test_that("chrome with remote hosts", {
     list(port = port, process = p)
   })
 
-  withr::defer(res$process$is_alive() || res$process$kill())
+  withr::defer(if (!res$process$is_alive()) res$process$kill())
 
   remote <- ChromeRemote$new(host = "localhost", port = res$port)
 

--- a/tests/testthat/test-chromote_session.R
+++ b/tests/testthat/test-chromote_session.R
@@ -31,9 +31,12 @@ test_that("ChromoteSession gets and sets viewport size", {
   skip_if_offline()
 
   page <- ChromoteSession$new(width = 400, height = 800, mobile = TRUE)
-  # viewport requires an active page
-  page$Page$navigate("https://example.com")
   withr::defer(page$close())
+
+  # viewport requires an active page
+  p <- page$Page$loadEventFired(wait_ = FALSE)
+  page$Page$navigate("https://example.com", wait_ = TRUE)
+  page$wait_for(p)
 
   init_size <- list(
     width = 400,
@@ -164,9 +167,12 @@ test_that("ChromoteSession with deviceScaleFactor = 0", {
   skip_if_offline()
 
   page <- ChromoteSession$new(width = 400, height = 800, mobile = TRUE)
-  # viewport requires an active page
-  page$Page$navigate("https://example.com")
   withr::defer(page$close())
+
+  # viewport requires an active page
+  p <- page$Page$loadEventFired(wait_ = FALSE)
+  page$Page$navigate("https://example.com", wait_ = TRUE)
+  page$wait_for(p)
 
   init_size <- list(
     width = 400,

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -57,6 +57,10 @@ test_that("with_chrome_version() manages Chromote object", {
     while (chromote_obj$is_alive() && Sys.time() < max_wait) {
       Sys.sleep(0.1)
     }
+    if (chromote_obj$is_alive()) {
+      print(chromote_obj)
+      print(chromote_obj$Target$getTargets())
+    }
     expect_false(chromote_obj$is_alive())
   }
 

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -63,7 +63,12 @@ test_that("with_chrome_version() manages Chromote object", {
     expect_false(chromote_obj$is_alive())
   }
 
-  chomote_128 <- NULL
+  chromote_128 <- NULL
+
+  # Another copy of chromote 128 that we start globally, should be unaffected
+  chromote_128_global <- Chromote$new(
+    browser = Chrome$new(path = chrome_versions_path("128.0.6612.0", "chrome"))
+  )
 
   with_chrome_version("128.0.6612.0", {
     expect_equal(find_chrome(), chrome_versions_path("128.0.6612.0"))
@@ -89,6 +94,11 @@ test_that("with_chrome_version() manages Chromote object", {
   })
 
   expect_closed(chromote_128)
+
+  # The global chromote 128 process is still running
+  expect_true(chromote_128_global$is_alive())
+  chromote_128_global$stop()
+  expect_closed(chromote_128_global)
 })
 
 test_that("with_chrome_version() works", {

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -57,9 +57,8 @@ test_that("with_chrome_version() manages Chromote object", {
     while (chromote_obj$is_alive() && Sys.time() < max_wait) {
       Sys.sleep(0.1)
     }
-    if (chromote_obj$is_alive()) {
-      print(chromote_obj)
-      print(chromote_obj$Target$getTargets())
+    if (Sys.time() >= max_wait) {
+      message("waited the full 10 seconds for the process to close")
     }
     expect_false(chromote_obj$is_alive())
   }

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -15,29 +15,6 @@ test_that("with_chrome_version('system') works", {
   )
 })
 
-with_retries <- function(fn, max_tries = 3) {
-  retry <- function(tried = 0) {
-    tryCatch(
-      {
-        fn()
-      },
-      error = function(err) {
-        tried <- tried + 1
-        if (tried >= max_tries) {
-          rlang::abort(
-            sprintf("Failed after %s tries", tried),
-            parent = err
-          )
-        } else {
-          retry(tried)
-        }
-      }
-    )
-  }
-
-  retry()
-}
-
 try_chromote_info <- function() {
   info <- chromote_info()
   if (!is.null(info$error)) {

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -58,7 +58,7 @@ test_that("with_chrome_version() manages Chromote object", {
       Sys.sleep(0.1)
     }
     if (Sys.time() >= max_wait) {
-      message("waited the full 10 seconds for the process to close")
+      warning("Waited the full 10 seconds for the process to close")
     }
     expect_false(chromote_obj$is_alive())
   }

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -30,12 +30,12 @@ test_that("with_chrome_version() manages Chromote object", {
   chrome_versions_add("129.0.6668.100", "chrome-headless-shell")
 
   expect_closed <- function(chromote_obj) {
-    max_wait <- Sys.time() + 10
+    max_wait <- Sys.time() + 15
     while (chromote_obj$is_alive() && Sys.time() < max_wait) {
       Sys.sleep(0.1)
     }
     if (Sys.time() >= max_wait) {
-      warning("Waited the full 10 seconds for the process to close")
+      warning("Waited the full 15 seconds for the process to close")
     }
     expect_false(chromote_obj$is_alive())
   }

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -71,11 +71,11 @@ test_that("with_chrome_version() manages Chromote object", {
   chrome_versions_add("129.0.6668.100", "chrome-headless-shell")
 
   expect_closed <- function(chromote_obj) {
-    max_wait <- Sys.time() + 5
+    max_wait <- Sys.time() + 10
     while (chromote_obj$is_alive() && Sys.time() < max_wait) {
       Sys.sleep(0.1)
     }
-    expect_false(!!chromote_obj$is_alive())
+    expect_false(chromote_obj$is_alive())
   }
 
   chomote_128 <- NULL

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -74,7 +74,7 @@ test_that("with_chrome_version() manages Chromote object", {
 
   # The global chromote 128 process is still running
   expect_true(chromote_128_global$is_alive())
-  chromote_128_global$stop()
+  chromote_128_global$close()
   expect_closed(chromote_128_global)
 })
 

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -48,24 +48,6 @@ try_chromote_info <- function() {
   list(path = info$path, version = info$version)
 }
 
-test_that("with_chrome_version() works", {
-  chrome_versions_add("128.0.6612.0", "chrome")
-
-  expect_snapshot(
-    with_chrome_version("128.0.6612.0", with_retries(try_chromote_info)),
-    variant = guess_platform()
-  )
-
-  with_chrome_version("128.0.6612.0", {
-    b <- ChromoteSession$new()
-
-    expect_match(
-      b$Runtime$evaluate("navigator.appVersion")$result$value,
-      "HeadlessChrome/128"
-    )
-  })
-})
-
 test_that("with_chrome_version() manages Chromote object", {
   chrome_versions_add("128.0.6612.0", "chrome")
   chrome_versions_add("129.0.6668.100", "chrome-headless-shell")
@@ -104,4 +86,22 @@ test_that("with_chrome_version() manages Chromote object", {
   })
 
   expect_closed(chromote_128)
+})
+
+test_that("with_chrome_version() works", {
+  chrome_versions_add("128.0.6612.0", "chrome")
+
+  expect_snapshot(
+    with_chrome_version("128.0.6612.0", with_retries(try_chromote_info)),
+    variant = guess_platform()
+  )
+
+  with_chrome_version("128.0.6612.0", {
+    b <- ChromoteSession$new()
+
+    expect_match(
+      b$Runtime$evaluate("navigator.appVersion")$result$value,
+      "HeadlessChrome/128"
+    )
+  })
 })

--- a/tests/testthat/test-manage.R
+++ b/tests/testthat/test-manage.R
@@ -49,6 +49,12 @@ test_that("with_chrome_version() manages Chromote object", {
 
   with_chrome_version("128.0.6612.0", {
     expect_equal(find_chrome(), chrome_versions_path("128.0.6612.0"))
+    if (!has_chromote()) {
+      skip(sprintf(
+        "Skipping because Chrome failed to start (%s)",
+        find_chrome()
+      ))
+    }
     chromote_128 <- default_chromote_object()
     chromote_129 <- NULL
 
@@ -57,6 +63,12 @@ test_that("with_chrome_version() manages Chromote object", {
         find_chrome(),
         chrome_versions_path("129.0.6668.100", "chrome-headless-shell")
       )
+      if (!has_chromote()) {
+        skip(sprintf(
+          "Skipping because Chrome failed to start (%s)",
+          find_chrome()
+        ))
+      }
       chromote_129 <- default_chromote_object()
 
       expect_true(chromote_129$is_alive())
@@ -87,6 +99,13 @@ test_that("with_chrome_version() works", {
   )
 
   with_chrome_version("128.0.6612.0", {
+    if (!has_chromote()) {
+      skip(sprintf(
+        "Skipping because Chrome failed to start (%s)",
+        find_chrome()
+      ))
+    }
+
     b <- ChromoteSession$new()
 
     expect_match(

--- a/vignettes/example-remote-hosts.Rmd
+++ b/vignettes/example-remote-hosts.Rmd
@@ -36,6 +36,24 @@ google-chrome --headless --remote-debugging-address=0.0.0.0 --remote-debugging-p
   --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
 ```
 
+Or you can launch this process in R:
+
+```{r eval=FALSE}
+library(chromote)
+
+args <- c(
+  get_chrome_args(),
+  "--headless",
+  "--remote-debugging-address=0.0.0.0",
+  "--remote-debugging-port=9222"
+)
+
+p <- processx::process$new(find_chrome(), args)
+
+# To (abruptly) stop this process when you're finished with it:
+p$kill()
+```
+
 Then, in your local R session, create a Chromote object with the `host` and `port` (you will need to use the correct IP address).
 Once it's created, you can spawn a session off of it which you can control as normal:
 


### PR DESCRIPTION
One of the flaky tests was a timing issue that was easily resolved by following our own [best practices for loading pages](https://rstudio.github.io/chromote/articles/example-loading-pages.html).

The other flaky test revealed that the `$respawn()` changes missed a subtle consideration for how we manage connections to remote Chrome instances via `ChromeRemote`:

* `ChromeRemote` and `Chrome` inherit from `Browser`, which previously only considered the local process in the `$is_alive()` method. Now, `ChromeRemote` gains it's own `$is_alive()` method that checks if the remote instance is alive by reading the `/json/version` endpoint.

* `Chromote$close()` would attempt to shut down the remote browser, but unlike a normal `Chromote` instance, by definition chromote is not managing the browser process (it's remote after all). Now, closing a `Chromote` session with a remote browser just closes the websocket connection.

* Both `Chromote$close()` and `Browser$close()` now have a `wait` argument that allows the caller to wait for the local process to exit before returning. Because we need to shut down the websocket connection _after_ the browser has exited gracefully, `wait = TRUE` in `Chromote$close()` but is set to `FALSE` in `Browser$close()` (in the second case, we may return control to R before the browser process is closed, this is okay).

* Given the last point, we no longer need separate `$stop()` and `$close()` methods; I've removed `$stop()` and now `with_chrome_version()` just closes the current default chromote object.