### PR TITLE
fix(view): Use default browser when using `chrome-headless-shell`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * `Chromote` and `ChromoteSesssion` gain an `$auto_events_enable_args()` method that sets that arguments used by chromote's auto-events feature when calling the `enable` command for a domain, e.g. `Fetch.enable`. (#208)
 
+* The `$view()` method of a `ChromoteSession` will now detect when `chrome-headless-shell` is being used and will use the system browser (via `utils::browseURL()`) rather than the Chrome instance attached to chromote. (#214)
+
 # chromote 0.4.0
 
 * Chrome v132 and later no longer support [old headless mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome). As such, `chromote` no longer defaults to using `--headless=old` and now uses `--headless` when running Chrome. You can still use the `chromote.headless` option or `CHROMOTE_HEADLESS` environment variable to configure the `--headless` flag if you're using an older version of Chrome. (#187)

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,14 +85,21 @@ browse_url <- function(path, chromote) {
   if (inherits(browser, "Chrome")) {
     # If locally available, use the local browser
     browser_path <- browser$get_path()
-    # Quote the path if using a non-windows machine
-    if (!is_windows()) browser_path <- shQuote(browser_path)
-    utils::browseURL(url, browser_path)
-  } else {
-    # Otherwise pray opening the url works as expected
-    # Users can set `options(browser=)` to override default behavior
-    utils::browseURL(url)
+    product <- chromote$Browser$getVersion(wait_ = TRUE)$product
+
+    # And if not chrome-headless-shell (which doesn't have a UI we can use)
+    if (!grepl("HeadlessChrome", product, fixed = TRUE)) {
+      # Quote the path if using a non-windows machine
+      if (!is_windows()) browser_path <- shQuote(browser_path)
+      utils::browseURL(url, browser_path)
+      return(invisible(url))
+    }
   }
+
+  # Otherwise pray opening the url works as expected
+  # Users can set `options(browser=)` to override default behavior
+  utils::browseURL(url)
+  invisible(url)
 }
 
 # =============================================================================


### PR DESCRIPTION
Fixes #213

When we detect that the browser is a version of `chrome-headless-shell`, we no longer use the browser attached to chromote for `$view()` and instead use the default browser, i.e. `browseURL()` without overriding `browser`.

We use `$Browser$getVersion()` and look specifically for `HeadlessChrome` in the `product` name. (We _could_ also look at the browser path and look for `chrome-headless-shell`, but the path could be anything.)

``` r
library(chromote) # rstudio/chromote

local_chrome_version(binary = "chrome-headless-shell")
#> chromote will now use version 134.0.6998.88 of `chrome-headless-shell` for
#> mac-arm64.

b <- ChromoteSession$new()
b$Page$navigate("https://posit.co")
#> $frameId
#> [1] "6185CAE4361D8ED98E56723DCA4C4B7F"
#> 
#> $loaderId
#> [1] "E133279CE9CBE47D2F9ACBC64BD5BAFE"

b$parent$Browser$getVersion()
#> $protocolVersion
#> [1] "1.3"
#> 
#> $product
#> [1] "HeadlessChrome/134.0.6998.88"
#> 
#> $revision
#> [1] "@7e3d5c978c6d3a6eda25692cfac7f893a2b20dd0"
#> 
#> $userAgent
#> [1] "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/134.0.6998.88 Safari/537.36"
#> 
#> $jsVersion
#> [1] "13.4.114.19"
```