### PR TITLE
Add `go_to()` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # chromote (development version)
 
+## New features
+
+* `ChromoteSession` gets a new helper method, `$go_to()`. This is an easier way of reliably waiting for a page load, instead of using `Page$loadEventFired()` and `Page$navigate()` together. (#221)
+
 # chromote 0.5.0
 
 ## New features

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -377,7 +377,7 @@ ChromoteSession <- R6Class(
     #' # Asynchronous navigation
     #' p <- b$go_to("https://www.r-project.org", wait_ = FALSE)
     #' p$then(function(value) print("Navigation complete!"))
-    #'
+    #' }
     go_to = function(
       url,
       ...,

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -32,7 +32,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new(height = 1080, width = 1920)
     #'
     #' # Navigate to page
-    #' b$navigate_to("http://www.r-project.org/")
+    #' b$go_to("http://www.r-project.org/")
     #'
     #' # View current chromote session
     #' if (interactive()) b$view()
@@ -195,7 +195,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$navigate_to("http://www.r-project.org/")
+    #' b$go_to("http://www.r-project.org/")
     #'
     #' # View current chromote session
     #' if (interactive()) b$view()
@@ -220,7 +220,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$navigate_to("http://www.r-project.org/")
+    #' b$go_to("http://www.r-project.org/")
     #'
     #' # Close current chromote session
     #' b$close()
@@ -369,16 +369,16 @@ ChromoteSession <- R6Class(
     #'
     #' @examples \dontrun{
     #' # Basic navigation
-    #' b$navigate_to("https://www.r-project.org")
+    #' b$go_to("https://www.r-project.org")
     #'
     #' # Navigation with delay
-    #' b$navigate_to("https://www.r-project.org", delay = 2)
+    #' b$go_to("https://www.r-project.org", delay = 2)
     #'
     #' # Asynchronous navigation
-    #' p <- b$navigate_to("https://www.r-project.org", wait_ = FALSE)
+    #' p <- b$go_to("https://www.r-project.org", wait_ = FALSE)
     #' p$then(function(value) print("Navigation complete!"))
     #'
-    navigate_to = function(
+    go_to = function(
       url,
       ...,
       delay = 0,
@@ -415,7 +415,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$navigate_to("http://www.r-project.org/")
+    #' b$go_to("http://www.r-project.org/")
     #'
     #' # Take screenshot
     #' tmppngfile <- tempfile(fileext = ".png")
@@ -454,7 +454,7 @@ ChromoteSession <- R6Class(
     #'   }
     #'
     #'   b2 <- b$new_session()
-    #'   b2$navigate_to(url, wait_ = FALSE)$
+    #'   b2$go_to(url, wait_ = FALSE)$
     #'     then(function(value) {
     #'       b2$screenshot(filename, wait_ = FALSE)
     #'     })$
@@ -542,7 +542,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$navigate_to("http://www.r-project.org/")
+    #' b$go_to("http://www.r-project.org/")
     #'
     #' # Take screenshot
     #' tmppdffile <- tempfile(fileext = ".pdf")
@@ -599,9 +599,9 @@ ChromoteSession <- R6Class(
     #'
     #' ```r
     #' b1 <- ChromoteSession$new()
-    #' b1$navigate_to("http://www.google.com")
+    #' b1$go_to("http://www.google.com")
     #' b2 <- b1$new_session()
-    #' b2$navigate_to("http://www.r-project.org/")
+    #' b2$go_to("http://www.r-project.org/")
     #' b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
     #' #> [1] "https://www.google.com/"
     #' b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
@@ -687,7 +687,7 @@ ChromoteSession <- R6Class(
     #' ```r
     #' b <- ChromoteSession$new()
     #' b$parent$debug_messages(TRUE)
-    #' b$navigate_to("https://www.r-project.org/")
+    #' b$go_to("https://www.r-project.org/")
     #' #> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
     #' # Turn off debug messages
     #' b$parent$debug_messages(FALSE)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -32,7 +32,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new(height = 1080, width = 1920)
     #'
     #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
+    #' b$navigate_to("http://www.r-project.org/")
     #'
     #' # View current chromote session
     #' if (interactive()) b$view()
@@ -195,7 +195,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
+    #' b$navigate_to("http://www.r-project.org/")
     #'
     #' # View current chromote session
     #' if (interactive()) b$view()
@@ -220,7 +220,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
+    #' b$navigate_to("http://www.r-project.org/")
     #'
     #' # Close current chromote session
     #' b$close()
@@ -365,7 +365,7 @@ ChromoteSession <- R6Class(
     #'
     #' @return If `wait_` is TRUE, returns invisible(NULL). If wait_ is FALSE,
     #'   returns a promise that resolves when navigation is complete. The
-    #'   promise resolves with the value from the Page.loadEventFired event.
+    #'   promise resolves with the value from the navigate command.
     #'
     #' @examples \dontrun{
     #' # Basic navigation
@@ -392,13 +392,13 @@ ChromoteSession <- R6Class(
         timeout_ = timeout_,
         wait_ = FALSE
       )
-      self$Page$navigate(url, ..., error_ = error_, wait_ = FALSE)
+      result <- self$Page$navigate(url, ..., error_ = error_, wait_ = FALSE)
 
       if (delay > 0) {
         # After loadEventFired, wait `delay` seconds.
         p <- p$then(function(value) {
           promise(function(resolve, reject) {
-            later(function() resolve(value), delay)
+            later(function() resolve(result), delay)
           })
         })
       }
@@ -415,7 +415,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
+    #' b$navigate_to("http://www.r-project.org/")
     #'
     #' # Take screenshot
     #' tmppngfile <- tempfile(fileext = ".png")
@@ -454,8 +454,7 @@ ChromoteSession <- R6Class(
     #'   }
     #'
     #'   b2 <- b$new_session()
-    #'   b2$Page$navigate(url, wait_ = FALSE)
-    #'   b2$Page$loadEventFired(wait_ = FALSE)$
+    #'   b2$navigate_to(url, wait_ = FALSE)$
     #'     then(function(value) {
     #'       b2$screenshot(filename, wait_ = FALSE)
     #'     })$
@@ -543,7 +542,7 @@ ChromoteSession <- R6Class(
     #' b <- ChromoteSession$new()
     #'
     #' # Navigate to page
-    #' b$Page$navigate("http://www.r-project.org/")
+    #' b$navigate_to("http://www.r-project.org/")
     #'
     #' # Take screenshot
     #' tmppdffile <- tempfile(fileext = ".pdf")
@@ -600,9 +599,9 @@ ChromoteSession <- R6Class(
     #'
     #' ```r
     #' b1 <- ChromoteSession$new()
-    #' b1$Page$navigate("http://www.google.com")
+    #' b1$navigate_to("http://www.google.com")
     #' b2 <- b1$new_session()
-    #' b2$Page$navigate("http://www.r-project.org/")
+    #' b2$navigate_to("http://www.r-project.org/")
     #' b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
     #' #> [1] "https://www.google.com/"
     #' b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
@@ -688,7 +687,7 @@ ChromoteSession <- R6Class(
     #' ```r
     #' b <- ChromoteSession$new()
     #' b$parent$debug_messages(TRUE)
-    #' b$Page$navigate("https://www.r-project.org/")
+    #' b$navigate_to("https://www.r-project.org/")
     #' #> SEND {"method":"Page.navigate","params":{"url":"https://www.r-project.org/"}| __truncated__}
     #' # Turn off debug messages
     #' b$parent$debug_messages(FALSE)

--- a/README.md
+++ b/README.md
@@ -128,17 +128,13 @@ If you have the viewer open and run the following, you’ll see the web
 page load in the viewer[^1]:
 
 ``` r
-b$Page$navigate("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 ```
 
-In the official Chrome DevTools Protocol (CDP) documentation, this is
-the
-[`Page.navigate`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate)
-command.
-
-In addition to full support of the CDP, `ChromoteSession` objects also
-some convenience methods, like `$screenshot()`. (See the Examples
-section below for more information about screenshots.)
+In addition to full support of the Chrome Devtools Protocol,
+`ChromoteSession` objects also have some convenience methods, like
+`$navigate_to()` and `$screenshot()`. (See the Examples section below
+for more information about screenshots.)
 
 ``` r
 # Saves to screenshot.png

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ If you have the viewer open and run the following, you’ll see the web
 page load in the viewer[^1]:
 
 ``` r
-b$go_to("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 ```
 
 In addition to full support of the Chrome Devtools Protocol,
 `ChromoteSession` objects also have some convenience methods, like
-`$go_to()` and `$screenshot()`. (See the Examples section below
+`$navigate_to()` and `$screenshot()`. (See the Examples section below
 for more information about screenshots.)
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ If you have the viewer open and run the following, you’ll see the web
 page load in the viewer[^1]:
 
 ``` r
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 ```
 
 In addition to full support of the Chrome Devtools Protocol,
 `ChromoteSession` objects also have some convenience methods, like
-`$navigate_to()` and `$screenshot()`. (See the Examples section below
+`$go_to()` and `$screenshot()`. (See the Examples section below
 for more information about screenshots.)
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ If you have the viewer open and run the following, you’ll see the web
 page load in the viewer[^1]:
 
 ``` r
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 ```
 
 In addition to full support of the Chrome Devtools Protocol,
 `ChromoteSession` objects also have some convenience methods, like
-`$navigate_to()` and `$screenshot()`. (See the Examples section below
-for more information about screenshots.)
+`$go_to()` and `$screenshot()`. (See the Examples section below for more
+information about screenshots.)
 
 ``` r
 # Saves to screenshot.png

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -55,6 +55,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-close}{\code{ChromoteSession$close()}}
 \item \href{#method-ChromoteSession-get_viewport_size}{\code{ChromoteSession$get_viewport_size()}}
 \item \href{#method-ChromoteSession-set_viewport_size}{\code{ChromoteSession$set_viewport_size()}}
+\item \href{#method-ChromoteSession-navigate_to}{\code{ChromoteSession$navigate_to()}}
 \item \href{#method-ChromoteSession-screenshot}{\code{ChromoteSession$screenshot()}}
 \item \href{#method-ChromoteSession-screenshot_pdf}{\code{ChromoteSession$screenshot_pdf()}}
 \item \href{#method-ChromoteSession-new_session}{\code{ChromoteSession$new_session()}}
@@ -271,6 +272,57 @@ return a \code{ChromoteSession} object directly.}
 \subsection{Returns}{
 Invisibly returns the previous viewport dimensions so that you
 can restore the viewport size, if desired.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ChromoteSession-navigate_to"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-navigate_to}{}}}
+\subsection{Method \code{navigate_to()}}{
+Navigate to a URL and wait for the page to load
+
+This method navigates to a specified URL and waits for the page load
+event to complete. This is a more reliable alternative to directly
+calling \code{Page$navigate()}, which can return before the page is actually
+loaded. This method also allows for an optional delay after the load
+event has fired, in case the page needs to load additional assets after
+that event.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$navigate_to(
+  url,
+  ...,
+  delay = 0,
+  callback_ = NULL,
+  error_ = NULL,
+  timeout_ = self$default_timeout,
+  wait_ = TRUE
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{url}}{The URL to navigate to.}
+
+\item{\code{...}}{Additional parameters passed to \code{Page$navigate()}.}
+
+\item{\code{delay}}{Number of seconds to wait after the page load event fires.}
+
+\item{\code{callback_}}{Function to call when the page load event fires.}
+
+\item{\code{error_}}{Function to call if an error occurs during navigation.}
+
+\item{\code{timeout_}}{Maximum time in seconds to wait for the page load event
+(defaults to session's `default_timeout``).}
+
+\item{\code{wait_}}{If \code{FALSE}, returns a promise that resolves when navigation
+is complete. If \code{TRUE} (default), blocks until navigation is complete.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+If \code{wait_} is TRUE, returns invisible(NULL). If wait_ is FALSE,
+returns a promise that resolves when navigation is complete. The
+promise resolves with the value from the Page.loadEventFired event.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -14,6 +14,22 @@ but this is not currently supported by chromote.
 \examples{
 
 ## ------------------------------------------------
+## Method `ChromoteSession$go_to`
+## ------------------------------------------------
+
+\dontrun{
+# Basic navigation
+b$go_to("https://www.r-project.org")
+
+# Navigation with delay
+b$go_to("https://www.r-project.org", delay = 2)
+
+# Asynchronous navigation
+p <- b$go_to("https://www.r-project.org", wait_ = FALSE)
+p$then(function(value) print("Navigation complete!"))
+}
+
+## ------------------------------------------------
 ## Method `ChromoteSession$auto_events_enable_args`
 ## ------------------------------------------------
 
@@ -324,6 +340,24 @@ If \code{wait_} is TRUE, returns invisible(NULL). If wait_ is FALSE,
 returns a promise that resolves when navigation is complete. The
 promise resolves with the value from the navigate command.
 }
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+# Basic navigation
+b$go_to("https://www.r-project.org")
+
+# Navigation with delay
+b$go_to("https://www.r-project.org", delay = 2)
+
+# Asynchronous navigation
+p <- b$go_to("https://www.r-project.org", wait_ = FALSE)
+p$then(function(value) print("Navigation complete!"))
+}
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ChromoteSession-screenshot"></a>}}

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -55,7 +55,7 @@ wait for a Chrome DevTools Protocol response.}
 \item \href{#method-ChromoteSession-close}{\code{ChromoteSession$close()}}
 \item \href{#method-ChromoteSession-get_viewport_size}{\code{ChromoteSession$get_viewport_size()}}
 \item \href{#method-ChromoteSession-set_viewport_size}{\code{ChromoteSession$set_viewport_size()}}
-\item \href{#method-ChromoteSession-navigate_to}{\code{ChromoteSession$navigate_to()}}
+\item \href{#method-ChromoteSession-go_to}{\code{ChromoteSession$go_to()}}
 \item \href{#method-ChromoteSession-screenshot}{\code{ChromoteSession$screenshot()}}
 \item \href{#method-ChromoteSession-screenshot_pdf}{\code{ChromoteSession$screenshot_pdf()}}
 \item \href{#method-ChromoteSession-new_session}{\code{ChromoteSession$new_session()}}
@@ -90,7 +90,7 @@ b <- ChromoteSession$new()
 b <- ChromoteSession$new(height = 1080, width = 1920)
 
 # Navigate to page
-b$navigate_to("http://www.r-project.org/")
+b$go_to("http://www.r-project.org/")
 
 # View current chromote session
 if (interactive()) b$view()
@@ -158,7 +158,7 @@ using your \code{\link{Chrome}} browser. When not using a \code{\link{Chrome}} b
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$navigate_to("http://www.r-project.org/")
+b$go_to("http://www.r-project.org/")
 
 # View current chromote session
 if (interactive()) b$view()
@@ -180,7 +180,7 @@ Close the Chromote session.
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$navigate_to("http://www.r-project.org/")
+b$go_to("http://www.r-project.org/")
 
 # Close current chromote session
 b$close()
@@ -275,9 +275,9 @@ can restore the viewport size, if desired.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-ChromoteSession-navigate_to"></a>}}
-\if{latex}{\out{\hypertarget{method-ChromoteSession-navigate_to}{}}}
-\subsection{Method \code{navigate_to()}}{
+\if{html}{\out{<a id="method-ChromoteSession-go_to"></a>}}
+\if{latex}{\out{\hypertarget{method-ChromoteSession-go_to}{}}}
+\subsection{Method \code{go_to()}}{
 Navigate to a URL and wait for the page to load
 
 This method navigates to a specified URL and waits for the page load
@@ -287,7 +287,7 @@ loaded. This method also allows for an optional delay after the load
 event has fired, in case the page needs to load additional assets after
 that event.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$navigate_to(
+\if{html}{\out{<div class="r">}}\preformatted{ChromoteSession$go_to(
   url,
   ...,
   delay = 0,
@@ -336,7 +336,7 @@ Take a PNG screenshot
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$navigate_to("http://www.r-project.org/")
+b$go_to("http://www.r-project.org/")
 
 # Take screenshot
 tmppngfile <- tempfile(fileext = ".png")
@@ -375,7 +375,7 @@ screenshot_p <- function(url, filename = NULL) \{
   \}
 
   b2 <- b$new_session()
-  b2$navigate_to(url, wait_ = FALSE)$
+  b2$go_to(url, wait_ = FALSE)$
     then(function(value) \{
       b2$screenshot(filename, wait_ = FALSE)
     \})$
@@ -468,7 +468,7 @@ Take a PDF screenshot
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$navigate_to("http://www.r-project.org/")
+b$go_to("http://www.r-project.org/")
 
 # Take screenshot
 tmppdffile <- tempfile(fileext = ".pdf")
@@ -530,9 +530,9 @@ Create a new tab / window
 \subsection{Examples}{
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{b1 <- ChromoteSession$new()
-b1$navigate_to("http://www.google.com")
+b1$go_to("http://www.google.com")
 b2 <- b1$new_session()
-b2$navigate_to("http://www.r-project.org/")
+b2$go_to("http://www.r-project.org/")
 b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
 #> [1] "https://www.google.com/"
 b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
@@ -639,7 +639,7 @@ Send a debug log message to the parent \link{Chromote} object
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
 b$parent$debug_messages(TRUE)
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 #> SEND \{"method":"Page.navigate","params":\{"url":"https://www.r-project.org/"\}| __truncated__\}
 # Turn off debug messages
 b$parent$debug_messages(FALSE)

--- a/man/ChromoteSession.Rd
+++ b/man/ChromoteSession.Rd
@@ -90,7 +90,7 @@ b <- ChromoteSession$new()
 b <- ChromoteSession$new(height = 1080, width = 1920)
 
 # Navigate to page
-b$Page$navigate("http://www.r-project.org/")
+b$navigate_to("http://www.r-project.org/")
 
 # View current chromote session
 if (interactive()) b$view()
@@ -158,7 +158,7 @@ using your \code{\link{Chrome}} browser. When not using a \code{\link{Chrome}} b
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$Page$navigate("http://www.r-project.org/")
+b$navigate_to("http://www.r-project.org/")
 
 # View current chromote session
 if (interactive()) b$view()
@@ -180,7 +180,7 @@ Close the Chromote session.
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$Page$navigate("http://www.r-project.org/")
+b$navigate_to("http://www.r-project.org/")
 
 # Close current chromote session
 b$close()
@@ -322,7 +322,7 @@ is complete. If \code{TRUE} (default), blocks until navigation is complete.}
 \subsection{Returns}{
 If \code{wait_} is TRUE, returns invisible(NULL). If wait_ is FALSE,
 returns a promise that resolves when navigation is complete. The
-promise resolves with the value from the Page.loadEventFired event.
+promise resolves with the value from the navigate command.
 }
 }
 \if{html}{\out{<hr>}}
@@ -336,7 +336,7 @@ Take a PNG screenshot
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$Page$navigate("http://www.r-project.org/")
+b$navigate_to("http://www.r-project.org/")
 
 # Take screenshot
 tmppngfile <- tempfile(fileext = ".png")
@@ -375,8 +375,7 @@ screenshot_p <- function(url, filename = NULL) \{
   \}
 
   b2 <- b$new_session()
-  b2$Page$navigate(url, wait_ = FALSE)
-  b2$Page$loadEventFired(wait_ = FALSE)$
+  b2$navigate_to(url, wait_ = FALSE)$
     then(function(value) \{
       b2$screenshot(filename, wait_ = FALSE)
     \})$
@@ -469,7 +468,7 @@ Take a PDF screenshot
 b <- ChromoteSession$new()
 
 # Navigate to page
-b$Page$navigate("http://www.r-project.org/")
+b$navigate_to("http://www.r-project.org/")
 
 # Take screenshot
 tmppdffile <- tempfile(fileext = ".pdf")
@@ -531,9 +530,9 @@ Create a new tab / window
 \subsection{Examples}{
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{b1 <- ChromoteSession$new()
-b1$Page$navigate("http://www.google.com")
+b1$navigate_to("http://www.google.com")
 b2 <- b1$new_session()
-b2$Page$navigate("http://www.r-project.org/")
+b2$navigate_to("http://www.r-project.org/")
 b1$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
 #> [1] "https://www.google.com/"
 b2$Runtime$evaluate("window.location", returnByValue = TRUE)$result$value$href
@@ -640,7 +639,7 @@ Send a debug log message to the parent \link{Chromote} object
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{b <- ChromoteSession$new()
 b$parent$debug_messages(TRUE)
-b$Page$navigate("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 #> SEND \{"method":"Page.navigate","params":\{"url":"https://www.r-project.org/"\}| __truncated__\}
 # Turn off debug messages
 b$parent$debug_messages(FALSE)

--- a/man/fragments/basic-usage.Rmd
+++ b/man/fragments/basic-usage.Rmd
@@ -42,12 +42,10 @@ b$Browser$getVersion()
 If you have the viewer open and run the following, you'll see the web page load in the viewer[^interactive]:
 
 ```R
-b$Page$navigate("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 ```
 
-In the official Chrome DevTools Protocol (CDP) documentation, this is the [`Page.navigate`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate) command.
-
-In addition to full support of the CDP, `ChromoteSession` objects also some convenience methods, like `$screenshot()`. (See the Examples section below for more information about screenshots.)
+In addition to full support of the Chrome Devtools Protocol, `ChromoteSession` objects also have some convenience methods, like `$navigate_to()` and `$screenshot()`. (See the Examples section below for more information about screenshots.)
 
 ```R
 # Saves to screenshot.png

--- a/man/fragments/basic-usage.Rmd
+++ b/man/fragments/basic-usage.Rmd
@@ -42,10 +42,10 @@ b$Browser$getVersion()
 If you have the viewer open and run the following, you'll see the web page load in the viewer[^interactive]:
 
 ```R
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 ```
 
-In addition to full support of the Chrome Devtools Protocol, `ChromoteSession` objects also have some convenience methods, like `$navigate_to()` and `$screenshot()`. (See the Examples section below for more information about screenshots.)
+In addition to full support of the Chrome Devtools Protocol, `ChromoteSession` objects also have some convenience methods, like `$go_to()` and `$screenshot()`. (See the Examples section below for more information about screenshots.)
 
 ```R
 # Saves to screenshot.png

--- a/vignettes/commands-and-events.Rmd
+++ b/vignettes/commands-and-events.Rmd
@@ -65,7 +65,7 @@ $timestamp
 ```
 
 > **Note:** This sequence of commands, with `Page$navigate()` and then `Page$loadEventFired()` works interactively when you run the commands slowly, but it will not work 100% of the time.
-> In practice you should use `$navigate_to()` instead for reliable loading.
+> In practice you should use `$go_to()` instead for reliable loading.
 > See `vignette("example-loading-page")` for more information.
 
 ## Automatic Events

--- a/vignettes/commands-and-events.Rmd
+++ b/vignettes/commands-and-events.Rmd
@@ -65,7 +65,8 @@ $timestamp
 ```
 
 > **Note:** This sequence of commands, with `Page$navigate()` and then `Page$loadEventFired()` works interactively when you run the commands slowly, but it will not work 100% of the time.
-> See `vignette("example-loading-page")` for a reliable approach to page loading that works in all situations.
+> In practice you should use `$navigate_to()` instead for reliable loading.
+> See `vignette("example-loading-page")` for more information.
 
 ## Automatic Events
 

--- a/vignettes/example-authentication.Rmd
+++ b/vignettes/example-authentication.Rmd
@@ -39,7 +39,7 @@ First navigate to the page:
 library(chromote)
 b <- ChromoteSession$new()
 b$view()
-b$Page$navigate("https://beta.rstudioconnect.com/content/123456/")
+b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
 ```
 
 Next, log in interactively via the viewer.
@@ -60,7 +60,7 @@ b$view()
 cookies <- readRDS("cookies.rds")
 b$Network$setCookies(cookies = cookies$cookies)
 # Navigate to the app that requires a login
-b$Page$navigate("https://beta.rstudioconnect.com/content/123456/")
+b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
 b$screenshot()
 ```
 
@@ -108,7 +108,7 @@ library(chromote)
 b <- ChromoteSession$new()
 
 b$Network$setCookies(cookies = cookies$cookies)
-b$Page$navigate("https://beta.rstudioconnect.com/content/123456/")
+b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
 
 b$screenshot()
 ```

--- a/vignettes/example-authentication.Rmd
+++ b/vignettes/example-authentication.Rmd
@@ -39,7 +39,7 @@ First navigate to the page:
 library(chromote)
 b <- ChromoteSession$new()
 b$view()
-b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
+b$go_to("https://beta.rstudioconnect.com/content/123456/")
 ```
 
 Next, log in interactively via the viewer.
@@ -60,7 +60,7 @@ b$view()
 cookies <- readRDS("cookies.rds")
 b$Network$setCookies(cookies = cookies$cookies)
 # Navigate to the app that requires a login
-b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
+b$go_to("https://beta.rstudioconnect.com/content/123456/")
 b$screenshot()
 ```
 
@@ -108,7 +108,7 @@ library(chromote)
 b <- ChromoteSession$new()
 
 b$Network$setCookies(cookies = cookies$cookies)
-b$navigate_to("https://beta.rstudioconnect.com/content/123456/")
+b$go_to("https://beta.rstudioconnect.com/content/123456/")
 
 b$screenshot()
 ```

--- a/vignettes/example-custom-headers.Rmd
+++ b/vignettes/example-custom-headers.Rmd
@@ -37,7 +37,7 @@ b$Network$setExtraHTTPHeaders(headers = list(
 ))
 
 # Visit a web page that prints out the request headers
-b$navigate_to("http://scooterlabs.com/echo")
+b$go_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
 
@@ -47,7 +47,7 @@ b$screenshot(show = TRUE)
 b$Network$setExtraHTTPHeaders(headers = list(a=1)[0])
 
 # Request again
-b$navigate_to("http://scooterlabs.com/echo")
+b$go_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
 

--- a/vignettes/example-custom-headers.Rmd
+++ b/vignettes/example-custom-headers.Rmd
@@ -37,7 +37,7 @@ b$Network$setExtraHTTPHeaders(headers = list(
 ))
 
 # Visit a web page that prints out the request headers
-b$Page$navigate("http://scooterlabs.com/echo")
+b$navigate_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
 
@@ -47,7 +47,7 @@ b$screenshot(show = TRUE)
 b$Network$setExtraHTTPHeaders(headers = list(a=1)[0])
 
 # Request again
-b$Page$navigate("http://scooterlabs.com/echo")
+b$navigate_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 
 

--- a/vignettes/example-custom-user-agent.Rmd
+++ b/vignettes/example-custom-user-agent.Rmd
@@ -33,7 +33,7 @@ b <- ChromoteSession$new()
 
 b$Network$setUserAgentOverride(userAgent = "My fake browser")
 
-b$Page$navigate("http://scooterlabs.com/echo")
+b$navigate_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 ```
 
@@ -45,7 +45,7 @@ b <- ChromoteSession$new()
 
 b$Network$setUserAgentOverride(userAgent = "My fake browser", wait_ = FALSE)
 p <- b$Page$loadEventFired(wait_ = FALSE)
-b$Page$navigate("http://scooterlabs.com/echo", wait_ = FALSE)
+b$navigate_to("http://scooterlabs.com/echo", wait_ = FALSE)
 p$then(function(value) {
   b$screenshot(show = TRUE)
 })

--- a/vignettes/example-custom-user-agent.Rmd
+++ b/vignettes/example-custom-user-agent.Rmd
@@ -33,7 +33,7 @@ b <- ChromoteSession$new()
 
 b$Network$setUserAgentOverride(userAgent = "My fake browser")
 
-b$navigate_to("http://scooterlabs.com/echo")
+b$go_to("http://scooterlabs.com/echo")
 b$screenshot(show = TRUE)
 ```
 
@@ -45,7 +45,7 @@ b <- ChromoteSession$new()
 
 b$Network$setUserAgentOverride(userAgent = "My fake browser", wait_ = FALSE)
 p <- b$Page$loadEventFired(wait_ = FALSE)
-b$navigate_to("http://scooterlabs.com/echo", wait_ = FALSE)
+b$go_to("http://scooterlabs.com/echo", wait_ = FALSE)
 p$then(function(value) {
   b$screenshot(show = TRUE)
 })

--- a/vignettes/example-extract-text.Rmd
+++ b/vignettes/example-extract-text.Rmd
@@ -28,7 +28,7 @@ One way to extract text from a page is to tell the browser to run JavaScript cod
 library(chromote)
 b <- ChromoteSession$new()
 
-b$Page$navigate("https://www.whatismybrowser.com/")
+b$navigate_to("https://www.whatismybrowser.com/")
 
 # Run JavaScript to extract text from the page
 x <- b$Runtime$evaluate('document.querySelector(".corset .string-major a").innerText')
@@ -43,7 +43,7 @@ library(chromote)
 b <- ChromoteSession$new()
 
 p <- b$Page$loadEventFired(wait_ = FALSE)
-b$Page$navigate("https://www.whatismybrowser.com/", wait_ = FALSE)
+b$navigate_to("https://www.whatismybrowser.com/", wait_ = FALSE)
 p$then(function(value) {
   b$Runtime$evaluate(
     'document.querySelector(".corset .string-major a").innerText'
@@ -54,7 +54,7 @@ then(function(value) {
 })
 ```
 
-## Using Chrome DevTools Procotol commands
+## Using Chrome DevTools Protocol commands
 
 Another way is to use CDP commands to extract content from the DOM.
 This does not require executing JavaScript in the browser's context, but it is also not as flexible as JavaScript.
@@ -65,7 +65,7 @@ This does not require executing JavaScript in the browser's context, but it is a
 library(chromote)
 b <- ChromoteSession$new()
 
-b$Page$navigate("https://www.whatismybrowser.com/")
+b$navigate_to("https://www.whatismybrowser.com/")
 x <- b$DOM$getDocument()
 x <- b$DOM$querySelector(x$root$nodeId, ".corset .string-major a")
 b$DOM$getOuterHTML(x$nodeId)
@@ -79,9 +79,8 @@ b$DOM$getOuterHTML(x$nodeId)
 library(chromote)
 b <- ChromoteSession$new()
 
-p <- b$Page$loadEventFired(wait_ = FALSE)
-b$Page$navigate("https://www.whatismybrowser.com/", wait_ = FALSE)
-p$then(function(value) {
+b$navigate_to("https://www.whatismybrowser.com/", wait_ = FALSE)$
+then(function(value) {
   b$DOM$getDocument()
 })$
 then(function(value) {

--- a/vignettes/example-extract-text.Rmd
+++ b/vignettes/example-extract-text.Rmd
@@ -28,7 +28,7 @@ One way to extract text from a page is to tell the browser to run JavaScript cod
 library(chromote)
 b <- ChromoteSession$new()
 
-b$navigate_to("https://www.whatismybrowser.com/")
+b$go_to("https://www.whatismybrowser.com/")
 
 # Run JavaScript to extract text from the page
 x <- b$Runtime$evaluate('document.querySelector(".corset .string-major a").innerText')
@@ -43,7 +43,7 @@ library(chromote)
 b <- ChromoteSession$new()
 
 p <- b$Page$loadEventFired(wait_ = FALSE)
-b$navigate_to("https://www.whatismybrowser.com/", wait_ = FALSE)
+b$go_to("https://www.whatismybrowser.com/", wait_ = FALSE)
 p$then(function(value) {
   b$Runtime$evaluate(
     'document.querySelector(".corset .string-major a").innerText'
@@ -65,7 +65,7 @@ This does not require executing JavaScript in the browser's context, but it is a
 library(chromote)
 b <- ChromoteSession$new()
 
-b$navigate_to("https://www.whatismybrowser.com/")
+b$go_to("https://www.whatismybrowser.com/")
 x <- b$DOM$getDocument()
 x <- b$DOM$querySelector(x$root$nodeId, ".corset .string-major a")
 b$DOM$getOuterHTML(x$nodeId)
@@ -79,7 +79,7 @@ b$DOM$getOuterHTML(x$nodeId)
 library(chromote)
 b <- ChromoteSession$new()
 
-b$navigate_to("https://www.whatismybrowser.com/", wait_ = FALSE)$
+b$go_to("https://www.whatismybrowser.com/", wait_ = FALSE)$
 then(function(value) {
   b$DOM$getDocument()
 })$

--- a/vignettes/example-loading-page.Rmd
+++ b/vignettes/example-loading-page.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-This document explains why you should use the convenience method `$navigate_to()`, instead of the lower-level Chrome Devtools Protocol command `Page$navigate()`.
+This document explains why you should use the convenience method `$navigate_to()` instead of the lower-level Chrome Devtools Protocol command `Page$navigate()`.
 
 
 ``` r

--- a/vignettes/example-loading-page.Rmd
+++ b/vignettes/example-loading-page.Rmd
@@ -18,6 +18,9 @@ knitr::opts_chunk$set(
 )
 ```
 
+This document explains why you should use the convenience method `$navigate_to()`, instead of the lower-level Chrome Devtools Protocol command `Page$navigate()`.
+
+
 ``` r
 library(chromote)
 b <- ChromoteSession$new()
@@ -64,4 +67,19 @@ p$then(function(value) {
 })
 ```
 
-This is explained in more detail in `vignette("sync-async")`.
+This method of calling `Page$loadEventFired()` before `Page$navigate()` is essentially what the `$navigate_to()` convenience method does. It can also operate in synchronous and asynchronous modes.
+
+``` r
+# Synchronous API
+b$Page$navigate_to("https://www.r-project.org/")
+b$screenshot("browser.png")
+
+# Asynchronous API
+b$Page$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
+then(function(value) {
+  b$screenshot("browser.png")
+})
+```
+
+
+The synchronous and asynchronous APIS are explained in more detail in `vignette("sync-async")`.

--- a/vignettes/example-loading-page.Rmd
+++ b/vignettes/example-loading-page.Rmd
@@ -82,4 +82,4 @@ then(function(value) {
 ```
 
 
-The synchronous and asynchronous APIS are explained in more detail in `vignette("sync-async")`.
+The synchronous and asynchronous APIs are explained in more detail in `vignette("sync-async")`.

--- a/vignettes/example-loading-page.Rmd
+++ b/vignettes/example-loading-page.Rmd
@@ -71,11 +71,11 @@ This method of calling `Page$loadEventFired()` before `Page$navigate()` is essen
 
 ``` r
 # Synchronous API
-b$Page$navigate_to("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 b$screenshot("browser.png")
 
 # Asynchronous API
-b$Page$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
+b$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
 then(function(value) {
   b$screenshot("browser.png")
 })

--- a/vignettes/example-loading-page.Rmd
+++ b/vignettes/example-loading-page.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-This document explains why you should use the convenience method `$navigate_to()` instead of the lower-level Chrome Devtools Protocol command `Page$navigate()`.
+This document explains why you should use the convenience method `$go_to()` instead of the lower-level Chrome Devtools Protocol command `Page$navigate()`.
 
 
 ``` r
@@ -67,15 +67,15 @@ p$then(function(value) {
 })
 ```
 
-This method of calling `Page$loadEventFired()` before `Page$navigate()` is essentially what the `$navigate_to()` convenience method does. It can also operate in synchronous and asynchronous modes.
+This method of calling `Page$loadEventFired()` before `Page$navigate()` is essentially what the `$go_to()` convenience method does. It can also operate in synchronous and asynchronous modes.
 
 ``` r
 # Synchronous API
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 b$screenshot("browser.png")
 
 # Asynchronous API
-b$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
+b$go_to("https://www.r-project.org/", wait_ = FALSE)$
 then(function(value) {
   b$screenshot("browser.png")
 })

--- a/vignettes/example-remote-hosts.Rmd
+++ b/vignettes/example-remote-hosts.Rmd
@@ -68,7 +68,7 @@ b <- r$new_session()
 
 b$Browser$getVersion()
 b$view()
-b$navigate_to("https://www.whatismybrowser.com/")
+b$go_to("https://www.whatismybrowser.com/")
 b$screenshot("browser.png")
 b$screenshot("browser_string.png", selector = ".string-major")
 ```

--- a/vignettes/example-remote-hosts.Rmd
+++ b/vignettes/example-remote-hosts.Rmd
@@ -68,8 +68,7 @@ b <- r$new_session()
 
 b$Browser$getVersion()
 b$view()
-b$Page$navigate("https://www.whatismybrowser.com/")
-b$Page$loadEventFired()
+b$navigate_to("https://www.whatismybrowser.com/")
 b$screenshot("browser.png")
 b$screenshot("browser_string.png", selector = ".string-major")
 ```
@@ -77,18 +76,3 @@ b$screenshot("browser_string.png", selector = ".string-major")
 When you use `$view()` on the remote browser, your local browser may block scripts for security reasons, which means that you won't be able to view the remote browser.
 If your local browser is Chrome, there will be a shield-shaped icon in the location bar that you can click in order to enable loading the scripts.
 (Note: Some browsers don't seem to work at all with the viewer.)
-
-**Technical note:** There seem to be some timing issues with remote browsers.
-In the example above, the browser may finish navigating to the web site before the R process receives the response message for `$navigate()`, and therefore before R starts waiting for `Page.loadEventFired`.
-In order to avoid these timing problems, it is better to write code like this:
-
-``` r
-{
-  p <- b$Page$loadEventFired(wait_ = FALSE)
-  b$Page$navigate("https://www.whatismybrowser.com/", wait_ = FALSE)
-  b$wait_for(p)
-}
-b$screenshot("browser.png")
-```
-
-This tells it to fire off the `Page.navigate` command and *not* wait for it, and then immediately start waiting for `Page.loadEventFired` event.

--- a/vignettes/example-screenshot.Rmd
+++ b/vignettes/example-screenshot.Rmd
@@ -32,11 +32,11 @@ b <- ChromoteSession$new()
 
 # ==== Synchronous version ====
 # Run the next two lines together, without any delay in between.
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 b$screenshot(show = TRUE)  # Saves to screenshot.png and displays in viewer
 
 # ==== Async version ====
-b$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
+b$go_to("https://www.r-project.org/", wait_ = FALSE)$
   then(function(value) {
     b$screenshot(show = TRUE)
   })
@@ -62,7 +62,7 @@ You can set the width and height when it is created:
 ``` r
 b <- ChromoteSession$new(width = 390, height = 844)
 
-b$navigate_to("https://www.r-project.org/")
+b$go_to("https://www.r-project.org/")
 b$screenshot("narrow.png")
 ```
 
@@ -88,7 +88,7 @@ The ChromoteSession's `$view()` method opens a regular browser and navigates to 
 b <- ChromoteSession$new()
 
 b$view()
-b$navigate_to("https://www.google.com") # Or just type the URL in the navigation bar
+b$go_to("https://www.google.com") # Or just type the URL in the navigation bar
 ```
 
 At this point, you can interact with the web page by typing in text and clicking on things.
@@ -122,7 +122,7 @@ screenshot_p <- function(url, filename = NULL) {
   }
 
   b <- ChromoteSession$new()
-  b$navigate_to(url, wait_ = FALSE)$
+  b$go_to(url, wait_ = FALSE)$
     then(function(value) {
       b$screenshot(filename, wait_ = FALSE)
     })$

--- a/vignettes/example-screenshot.Rmd
+++ b/vignettes/example-screenshot.Rmd
@@ -30,17 +30,14 @@ This uses Chromote's `$screenshot()` method, which wraps up many calls to the Ch
 ``` r
 b <- ChromoteSession$new()
 
-# ==== Semi-synchronous version ====
+# ==== Synchronous version ====
 # Run the next two lines together, without any delay in between.
-p <- b$Page$loadEventFired(wait_ = FALSE)
-b$Page$navigate("https://www.r-project.org/", wait_ = FALSE)
-b$wait_for(p)
+b$navigate_to("https://www.r-project.org/")
 b$screenshot(show = TRUE)  # Saves to screenshot.png and displays in viewer
 
 # ==== Async version ====
-p <- b$Page$loadEventFired(wait_ = FALSE)
-b$Page$navigate("https://www.r-project.org/", wait_ = FALSE)
-p$then(function(value) {
+b$navigate_to("https://www.r-project.org/", wait_ = FALSE)$
+  then(function(value) {
     b$screenshot(show = TRUE)
   })
 ```
@@ -65,7 +62,7 @@ You can set the width and height when it is created:
 ``` r
 b <- ChromoteSession$new(width = 390, height = 844)
 
-b$Page$navigate("https://www.r-project.org/")
+b$navigate_to("https://www.r-project.org/")
 b$screenshot("narrow.png")
 ```
 
@@ -91,7 +88,7 @@ The ChromoteSession's `$view()` method opens a regular browser and navigates to 
 b <- ChromoteSession$new()
 
 b$view()
-b$Page$navigate("https://www.google.com") # Or just type the URL in the navigation bar
+b$navigate_to("https://www.google.com") # Or just type the URL in the navigation bar
 ```
 
 At this point, you can interact with the web page by typing in text and clicking on things.
@@ -125,9 +122,8 @@ screenshot_p <- function(url, filename = NULL) {
   }
 
   b <- ChromoteSession$new()
-  p <- b$Page$loadEventFired(wait_ = FALSE)
-  b$Page$navigate(url, wait_ = FALSE)
-  p$then(function(value) {
+  b$navigate_to(url, wait_ = FALSE)$
+    then(function(value) {
       b$screenshot(filename, wait_ = FALSE)
     })$
     then(function(value) {

--- a/vignettes/sync-async.Rmd
+++ b/vignettes/sync-async.Rmd
@@ -457,7 +457,7 @@ str(b$wait_for(p))
 #>  $ timestamp: num 683
 ```
 
-`b$navigate_to()` is a convenience method that does things in this order, and in most cases you should use it instead of calling `Page$navigate()` directly.
+`b$go_to()` is a convenience method that does things in this order, and in most cases you should use it instead of calling `Page$navigate()` directly.
 
 > **Technical note**
 >

--- a/vignettes/sync-async.Rmd
+++ b/vignettes/sync-async.Rmd
@@ -457,6 +457,8 @@ str(b$wait_for(p))
 #>  $ timestamp: num 683
 ```
 
+`b$navigate_to()` is a convenience method that does things in this order, and in most cases you should use it instead of calling `Page$navigate()` directly.
+
 > **Technical note**
 >
 > The Chrome DevTools Protocol itself does not automatically enable event notifications.

--- a/vignettes/which-chrome.Rmd
+++ b/vignettes/which-chrome.Rmd
@@ -118,7 +118,7 @@ Sys.setenv(CHROMOTE_CHROME = "/Applications/Chromium.app/Contents/MacOS/Chromium
 
 b <- ChromoteSession$new()
 b$view()
-b$navigate_to("https://www.whatismybrowser.com/")
+b$go_to("https://www.whatismybrowser.com/")
 ```
 
 Another way is create a `Chromote` object and explicitly specify the browser, then spawn `ChromoteSession`s from it.
@@ -130,7 +130,7 @@ m <- Chromote$new(
 
 # Spawn a ChromoteSession from the Chromote object
 b <- m$new_session()
-b$navigate_to("https://www.whatismybrowser.com/")
+b$go_to("https://www.whatismybrowser.com/")
 ```
 
 Yet another way is to create a `Chromote` object with a specified browser, then set it as the default Chromote object.

--- a/vignettes/which-chrome.Rmd
+++ b/vignettes/which-chrome.Rmd
@@ -118,7 +118,7 @@ Sys.setenv(CHROMOTE_CHROME = "/Applications/Chromium.app/Contents/MacOS/Chromium
 
 b <- ChromoteSession$new()
 b$view()
-b$Page$navigate("https://www.whatismybrowser.com/")
+b$navigate_to("https://www.whatismybrowser.com/")
 ```
 
 Another way is create a `Chromote` object and explicitly specify the browser, then spawn `ChromoteSession`s from it.
@@ -130,7 +130,7 @@ m <- Chromote$new(
 
 # Spawn a ChromoteSession from the Chromote object
 b <- m$new_session()
-b$Page$navigate("https://www.whatismybrowser.com/")
+b$navigate_to("https://www.whatismybrowser.com/")
 ```
 
 Yet another way is to create a `Chromote` object with a specified browser, then set it as the default Chromote object.


### PR DESCRIPTION
Closes #177.

This adds a `$go_to()` method which creates the `loadEventFired` promise, then calls `navigate()`, then either returns the promise or waits for it, depending on the value of `wait_`.

With this method, we can simplify the docs and remove some of the caveats about it not always loading pages reliably.

If we want to take this, then we'll also need to update the docs and examples.