### PR TITLE
fix(ChromoteSession): `$view()` tries old inspector path first

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `ChromoteSession` gets a new helper method, `$go_to()`. This is an easier way of reliably waiting for a page load, instead of using `Page$loadEventFired()` and `Page$navigate()` together. (#221)
 
-* `ChromoteSession$view()` now accommodates the new DevTools Frontend URL used by Chrome v135 and later (#225).
+* `ChromoteSession$view()` now accommodates the new DevTools Frontend URL used by Chrome v135 and later (#225, #226).
 
 # chromote 0.5.0
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -224,8 +224,7 @@ ChromoteSession <- R6Class(
         if (length(inspector_contents) > 0) {
           ws_url <- info$webSocketDebuggerUrl[info$id == private$target_id]
           ws_url <- sub("ws://", "ws=", ws_url)
-          inspector_url <- paste0(inspector_path, "?", ws_url)
-          return(browse_url(inspector_url, self$parent))
+          path <- paste0(inspector_path, "?", ws_url)
         }
       }
 

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -204,8 +204,29 @@ ChromoteSession <- R6Class(
       # A data frame of targets, one row per target.
       info <- fromJSON(self$parent$url("/json"))
       path <- info$devtoolsFrontendUrl[info$id == private$target_id]
+
       if (length(path) == 0) {
         stop("Target info not found.")
+      }
+
+      if (!grepl("^/", path)) {
+        # Chrome v135+ uses a fully-qualified appspot.com URL because some
+        # flavors of Chrome do not ship with the devtools inspector (iOS,
+        # Android). Using this URL requires also setting
+        # ` -remote-allow-origins=https://chrome-devtools-frontend.appspot.com`.
+        # This is cumbersome and not required for desktop Chrome, so we instead
+        # use the legacy path, while trying to guard against future changes.
+        inspector_path <- "/devtools/inspector.html"
+        inspector_contents <- tryCatch(
+          readLines(self$parent$url(inspector_path)),
+          error = function(err) character(0)
+        )
+        if (length(inspector_contents) > 0) {
+          ws_url <- info$webSocketDebuggerUrl[info$id == private$target_id]
+          ws_url <- sub("ws://", "ws=", ws_url)
+          inspector_url <- paste0(inspector_path, "?", ws_url)
+          return(browse_url(inspector_url, self$parent))
+        }
       }
 
       browse_url(path, self$parent)

--- a/R/chromote_session.R
+++ b/R/chromote_session.R
@@ -209,11 +209,11 @@ ChromoteSession <- R6Class(
         stop("Target info not found.")
       }
 
-      if (!grepl("^/", path)) {
+      if (grepl("^https://chrome-devtools-frontend\\.appspot\\.com", path)) {
         # Chrome v135+ uses a fully-qualified appspot.com URL because some
         # flavors of Chrome do not ship with the devtools inspector (iOS,
         # Android). Using this URL requires also setting
-        # ` -remote-allow-origins=https://chrome-devtools-frontend.appspot.com`.
+        # `--remote-allow-origins=https://chrome-devtools-frontend.appspot.com`.
         # This is cumbersome and not required for desktop Chrome, so we instead
         # use the legacy path, while trying to guard against future changes.
         inspector_path <- "/devtools/inspector.html"


### PR DESCRIPTION
Fixes #224, stacks on #225

The `$view()` method now composes and tries the older `/devtools/inspector.html` path rather than using the fully-qualified chrome-devtools-frontend.appspot.com URL.